### PR TITLE
 Initial Metadata implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .rspec_status
 repos/*
+.DS_Store

--- a/lib/heroku_buildpack_ruby.rb
+++ b/lib/heroku_buildpack_ruby.rb
@@ -1,5 +1,6 @@
 require_relative "heroku_buildpack_ruby/prepare_app_bundler_and_ruby.rb"
 require_relative "heroku_buildpack_ruby/bundle_install.rb"
+require_relative "heroku_buildpack_ruby/metadata.rb"
 
 # This is the main entry point for the Ruby buildpack
 #
@@ -20,21 +21,28 @@ module HerokuBuildpackRuby
   def self.compile_legacy(build_dir: , cache_dir:, env_dir: , buildpack_ruby_path:)
     export = BUILDPACK_DIR.join("export")
     app_dir = Pathname.new(build_dir)
+    cache_dir = Pathname.new(cache_dir)
     vendor_dir = app_dir.join(".heroku/ruby")
-    user_comms = UserComms::V2.new
+    metadata_dir = cache_dir.join("vendor/heroku")
     profile_d_path = app_dir.join(".profile.d/ruby.sh")
+
+    metadata = Metadata.new(dir: metadata_dir, type: Metadata::V2)
+    user_comms = UserComms::V2.new
 
     PrepareAppBundlerAndRuby.new(
       app_dir: app_dir,
+      metadata: metadata,
       vendor_dir: vendor_dir,
       user_comms: user_comms,
       buildpack_ruby_path: buildpack_ruby_path,
     ).call
 
     # TODO detect and install binary dependencies here
+    # TODO Gem caching
 
     BundleInstall.new(
       app_dir: app_dir,
+      metadata: metadata,
       user_comms: user_comms,
       bundle_without_default: "development:test",
       bundle_install_gems_dir: vendor_dir.join("gems"),
@@ -51,19 +59,24 @@ module HerokuBuildpackRuby
     app_dir = Pathname.new(app_dir)
     layers_dir = Pathname.new(layers_dir)
     vendor_dir = app_dir.join(".heroku/ruby")
+
+    metadata = Metadata.new(dir: layers_dir, type: Metadata::CNB)
     user_comms = UserComms::CNB.new
 
     PrepareAppBundlerAndRuby.new(
       app_dir: app_dir,
+      metadata: metadata,
       vendor_dir: vendor_dir,
       user_comms: user_comms,
       buildpack_ruby_path: buildpack_ruby_path,
     ).call
 
     # TODO detect and install binary dependencies here
+    # TODO Gem caching
 
     BundleInstall.new(
       app_dir: app_dir,
+      metadata: metadata,
       user_comms: user_comms,
       bundle_without_default: "development:test",
       bundle_install_gems_dir: vendor_dir.join("gems"),

--- a/lib/heroku_buildpack_ruby/bundle_install.rb
+++ b/lib/heroku_buildpack_ruby/bundle_install.rb
@@ -10,9 +10,10 @@ module HerokuBuildpackRuby
 
     private; attr_reader :bundle_output, :bundle_without_default, :bundle_install_gems_dir, :user_comms, :bundle_gems_binsub_dir; public
 
-    def initialize(app_dir: , bundle_without_default: , bundle_install_gems_dir:, user_comms: )
+    def initialize(app_dir: , bundle_without_default: , bundle_install_gems_dir:, user_comms: , metadata: MetadataNull.new)
       @user_comms = user_comms
       @app_dir = Pathname.new(app_dir)
+      @metadata = metadata
       @bundle_without_default = bundle_without_default
       @bundle_install_gems_dir = Pathname.new(bundle_install_gems_dir)
       @bundle_gems_binsub_dir = @bundle_install_gems_dir.join("bin")

--- a/lib/heroku_buildpack_ruby/metadata.rb
+++ b/lib/heroku_buildpack_ruby/metadata.rb
@@ -1,0 +1,51 @@
+module HerokuBuildpackRuby
+
+  # The main interface for writing durable data to a metadata store
+  #
+  # Initialize using the desired backend:
+  #
+  #   metadata = Metadata.new(dir: cache_dir, type: Metadata::V2)
+  #   metadata = Metadata.new(dir: layers_dir, type: Metadata::CNB)
+  #
+  # Once an instance is created you must request a named layer:
+  #
+  #   metadata.layer(:ruby)
+  #
+  # This will return a metadata instance for that layer that responds
+  # to a standard interface `get`, `set`, and `fetch`:
+  #
+  #   metadata.layer(:ruby).set(version: "2.7.2")
+  #   puts metadata.layer(:ruby).get(:version)
+  #   # => "2.7.2"
+  #
+  # For testing you can use the MetadatNull class which behaves like
+  # Metadata, but it is backed by an in-memory hash and does not persist
+  # to disk.
+  class Metadata
+    def initialize(dir: , type: )
+      @engines = Hash.new {|h, k| h[k] = type.new(dir: dir, name: k) }
+    end
+
+    def layer(key)
+      @engines[key]
+    end
+  end
+
+  # TODO migrate from old V2 structure to new V2 structure
+
+  require_relative "metadata/v2.rb"
+  require_relative "metadata/cnb.rb"
+  require_relative "metadata/in_memory.rb"
+
+  # Useful for for isolating behavior in unit tests
+  #
+  # Values set are stored as a hash but do not persist to disk
+  #
+  #   metadata = MetadataNull.new
+  class MetadataNull < Metadata
+    def initialize(dir: nil, type: Metadata::InMemory)
+      super
+    end
+  end
+end
+

--- a/lib/heroku_buildpack_ruby/metadata/cnb.rb
+++ b/lib/heroku_buildpack_ruby/metadata/cnb.rb
@@ -1,0 +1,69 @@
+module HerokuBuildpackRuby
+  class Metadata
+
+    # An interface for a durable metadata store for CNB (bin/build)
+    #
+    # Will persist values to a CNB layer's `store.toml` durably
+    # so that it can persist between builds.
+    #
+    # Example:
+    #
+    #   layers_dir = Dir.pwd
+    #   metadata = Metadata::CNB.new(dir: layers_dir, name: :ruby)
+    #   metadata.set(:foo => "bar")
+    #   metadata.get(:foo) # => "bar"
+    #   metadata.fetch(:cinco) do
+    #     "a good boy"
+    #   end
+    #   # => "a good boy"
+    class CNB
+      def initialize(dir: ,name:)
+        @store = Pathname.new(dir).join(name.to_s, "store.toml").tap {|p| p.dirname.mkpath; FileUtils.touch(p) }
+        read
+      end
+
+      def exists?(key)
+        @metadata.key?(key)
+      end
+      alias :exist? :exists?
+
+      def get(key)
+        @metadata[key]
+      end
+
+      def set(hash={})
+        hash.each do |k, v|
+          @metadata[k] = v
+        end
+        write
+
+        self
+      end
+
+      def fetch(key)
+        return @metadata[key] if @metadata.key?(key)
+
+        value = yield
+        set(key => value)
+        write
+
+        value
+      end
+
+
+      def to_h
+        @metadata.dup
+      end
+
+      private def write
+        @toml[:metadata] = @metadata
+        @store.write TOML::Dumper.new(@toml).to_s
+      end
+
+      private def read
+        @toml = TOML.load(@store.read) || {}
+        @metadata = @toml[:metadata] || {}
+      end
+    end
+  end
+end

--- a/lib/heroku_buildpack_ruby/metadata/in_memory.rb
+++ b/lib/heroku_buildpack_ruby/metadata/in_memory.rb
@@ -1,0 +1,45 @@
+module HerokuBuildpackRuby
+  # A temporary in-memory metadata store
+  # mostly used for testing
+  #
+  # Example:
+  #
+  #   metadata = Metadata::InMemory.new
+  #   metadata.set(:foo => "bar")
+  #   metadata.get(:foo) # => "bar"
+  #   metadata.fetch(:cinco) do
+  #     "a good boy"
+  #   end
+  #   # => "a good boy"
+  class Metadata
+    class InMemory
+      def initialize(dir: nil, name: nil)
+        @metadata = {}
+      end
+
+      def exists?(key)
+        @metadata.key?(key)
+      end
+      alias :exist? :exists?
+
+      def get(key)
+        @metadata[key]
+      end
+
+      def set(hash = {})
+        @metadata.merge!(hash)
+
+        @metadata.transform_values!(&:to_s)
+        self
+      end
+
+      def fetch(key)
+        @metadata[key] if @metadata.key?(key)
+        value = yield
+
+        set(key => value)
+        value
+      end
+    end
+  end
+end

--- a/lib/heroku_buildpack_ruby/metadata/v2.rb
+++ b/lib/heroku_buildpack_ruby/metadata/v2.rb
@@ -1,0 +1,63 @@
+module HerokuBuildpackRuby
+  class Metadata
+
+    # An interface for a durable metadata store for legacy/V2 (bin/compile)
+    #
+    # Will persist values to a directory using keys as filenames and
+    # contents as their values.
+    #
+    # Example:
+    #
+    #   cache_dir = Dir.pwd
+    #   metadata = Metadata::V2.new(dir: cache_dir, name: :ruby)
+    #   metadata.set(:foo => "bar")
+    #   metadata.get(:foo) # => "bar"
+    #   metadata.fetch(:cinco) do
+    #     "a good boy"
+    #   end
+    #   # => "a good boy"
+    class V2
+      def initialize(dir: ,name:)
+        @dir = Pathname.new(dir).join(name.to_s).tap(&:mkpath)
+        @metadata = {}
+
+        @dir.entries.each do |entry|
+          path = @dir.join(entry)
+          next if path.directory?
+
+          @metadata[entry.to_s.to_sym] = path.read
+        end
+      end
+
+      def exists?(key)
+        @metadata.key?(key)
+      end
+      alias :exist? :exists?
+
+      def get(key)
+        @metadata[key]
+      end
+
+      def set(hash = {})
+        hash.each do |k, v|
+          @metadata[k] = v
+          @dir.join(k.to_s).write v.to_s
+        end
+        self
+      end
+
+      def fetch(key)
+        @metadata[key] if @metadata.key?(key)
+
+        value = yield
+        set(key => value)
+
+        value
+      end
+
+      def to_h
+        @metadata.dup
+      end
+    end
+  end
+end

--- a/lib/heroku_buildpack_ruby/prepare_app_bundler_and_ruby.rb
+++ b/lib/heroku_buildpack_ruby/prepare_app_bundler_and_ruby.rb
@@ -35,10 +35,11 @@ module HerokuBuildpackRuby
     private; attr_reader :user_comms, :vendor_dir, :app_dir, :ruby_install_dir, :bundler_install_dir, :bundler_detect_version, :ruby_detect_version; public
     public; attr_reader :gem_install_dir
 
-    def initialize(vendor_dir: , app_dir: , buildpack_ruby_path: , user_comms: UserComms::V2.new)
-      @user_comms = user_comms
-      @vendor_dir = Pathname.new(vendor_dir)
+    def initialize(vendor_dir: , app_dir: , buildpack_ruby_path: , user_comms: UserComms::V2.new, metadata: MetadataNull.new)
       @app_dir = Pathname.new(app_dir)
+      @metadata = metadata
+      @vendor_dir = Pathname.new(vendor_dir)
+      @user_comms = user_comms
 
       @gem_install_dir = @vendor_dir.join("gems")
       @ruby_install_dir = @vendor_dir.join("dir")
@@ -71,6 +72,8 @@ module HerokuBuildpackRuby
       @bundler_detect_version.call
       bundler_version = @bundler_detect_version.version
       @user_comms.topic("Installing bundler #{bundler_version}")
+
+      # TODO remove BUNDLE WITH version in Gemfile.lock
       # @user.topic("Removing BUNDLED WITH version in the Gemfile.lock")
       bundler_version
     end
@@ -93,7 +96,6 @@ module HerokuBuildpackRuby
       ).call
     end
 
-    # TODO: Cloud native buildpack
     def configure_ruby_and_bundler_env_vars!
       PATH_ENV.prepend(
         ruby: @ruby_install_dir.join("bin"),
@@ -108,5 +110,4 @@ module HerokuBuildpackRuby
     end
   end
 end
-
 

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -1,0 +1,100 @@
+require_relative "../spec_helper.rb"
+
+RSpec.describe "metadata" do
+  describe "top level interface" do
+    it "works" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname.new(dir)
+        metadata = HerokuBuildpackRuby::Metadata.new(dir: dir, type: HerokuBuildpackRuby::Metadata::CNB)
+        expect(metadata.layer(:ruby).class).to eq(HerokuBuildpackRuby::Metadata::CNB)
+
+        metadata = HerokuBuildpackRuby::Metadata.new(dir: dir, type: HerokuBuildpackRuby::Metadata::V2)
+        expect(metadata.layer(:ruby).class).to eq(HerokuBuildpackRuby::Metadata::V2)
+      end
+    end
+
+    it "null can be created with no directory or type" do
+      null = HerokuBuildpackRuby::MetadataNull.new
+      null.layer(:ruby).set(version: "2.7.2")
+      expect(null.layer(:ruby).get(:version)).to eq("2.7.2")
+    end
+  end
+
+  describe "in memory Engine" do
+    it "works" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname.new(dir)
+        engine = HerokuBuildpackRuby::Metadata::InMemory.new(dir: dir, name: :ruby)
+        expect(engine.get(:foo)).to be_nil
+        engine.set(foo: "bar")
+        expect(engine.get(:foo)).to eq("bar")
+
+        expect(engine.get(:lol)).to eq(nil)
+        out = engine.fetch(:lol) do
+          "haha"
+        end
+
+        expect(out).to eq("haha")
+        expect(engine.get(:lol)).to eq("haha")
+      end
+    end
+  end
+
+  describe "CNB Engine" do
+    it "works" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname.new(dir)
+        engine = HerokuBuildpackRuby::Metadata::CNB.new(dir: dir, name: :ruby)
+        expect(engine.get(:foo)).to be_nil
+        engine.set(foo: "bar")
+        expect(engine.get(:foo)).to eq("bar")
+
+        expect(engine.get(:lol)).to eq(nil)
+        out = engine.fetch(:lol) do
+          "haha"
+        end
+
+        expect(out).to eq("haha")
+        expect(engine.get(:lol)).to eq("haha")
+
+        hash = HerokuBuildpackRuby::TOML.load(dir.join("ruby", "store.toml").read)
+        expect(hash).to eq({:metadata=>{:foo=>"bar", :lol=>"haha"}})
+
+
+        engine_2 = HerokuBuildpackRuby::Metadata::CNB.new(dir: dir, name: :ruby)
+
+        expect(engine_2.to_h).to eq(engine.to_h)
+      end
+    end
+  end
+
+  describe "V2 Engine" do
+    it "works" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname.new(dir)
+        engine = HerokuBuildpackRuby::Metadata::V2.new(dir: dir, name: :ruby)
+        expect(engine.get(:foo)).to be_nil
+        engine.set(foo: "bar")
+        expect(engine.get(:foo)).to eq("bar")
+
+        expect(engine.get(:lol)).to eq(nil)
+        out = engine.fetch(:lol) do
+          "haha"
+        end
+
+        expect(out).to eq("haha")
+        expect(engine.get(:lol)).to eq("haha")
+
+        expect(dir.join("ruby").entries.map(&:to_s)).to include("lol")
+        expect(dir.join("ruby").entries.map(&:to_s)).to include("foo")
+
+        expect(dir.join("ruby", "foo").read).to eq("bar")
+        expect(dir.join("ruby", "lol").read).to eq("haha")
+
+
+        engine_2 = HerokuBuildpackRuby::Metadata::V2.new(dir: dir, name: :ruby)
+        expect(engine_2.to_h).to eq(engine.to_h)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This implementation uses the same interface for V2 and CNB. A top level Metadata object is a loose wrapper around a low level metadata store that responds to get/set/fetch. 

I do need to figure out a migration strategy to migrate from existing heroku-buildpack-ruby metadata to this scheme, but that can come later.

As values are set on the metadata stores they're written to disk right away so we don't have to worry about remembering to write to disk when we're done. 

A layer is currently represented as 3 things:

- env
- config
- metadata (store.toml)

Currently, EnvProxy handles writing the env and the config. With the addition of this store, we've got a fairly comprehensive view for a layer. It's a little odd that the EnvProxy knows about config. I might want to change that in the future. But for now it's probably fine.

There are some possible safety concerns. I'm not sure what happens if we write to a `store.toml` that is not configured. (build/launch/cache). We might need to add some guard statements like how EnvProxy will validate a layer before letting you write an env var to it.

I explicitly wanted a non-hash-like interface for this metadata so that it would be crystal clear that a custom object is being interacted with. Currently nothing in the codebase is _using_ the metadata store , which is a bit odd for me. From a process perspective I usually only implement when I'm also using the interface. But I'm very satisfied with the current implementation.

