### PR TITLE
Default Ruby versions are sticky

### DIFF
--- a/lib/heroku_buildpack_ruby/metadata/in_memory.rb
+++ b/lib/heroku_buildpack_ruby/metadata/in_memory.rb
@@ -34,7 +34,7 @@ module HerokuBuildpackRuby
       end
 
       def fetch(key)
-        @metadata[key] if @metadata.key?(key)
+        return @metadata[key] if @metadata.key?(key)
         value = yield
 
         set(key => value)

--- a/lib/heroku_buildpack_ruby/metadata/v2.rb
+++ b/lib/heroku_buildpack_ruby/metadata/v2.rb
@@ -47,7 +47,7 @@ module HerokuBuildpackRuby
       end
 
       def fetch(key)
-        @metadata[key] if @metadata.key?(key)
+        return @metadata[key] if @metadata.key?(key)
 
         value = yield
         set(key => value)

--- a/lib/heroku_buildpack_ruby/prepare_app_bundler_and_ruby.rb
+++ b/lib/heroku_buildpack_ruby/prepare_app_bundler_and_ruby.rb
@@ -50,6 +50,7 @@ module HerokuBuildpackRuby
       )
 
       @ruby_detect_version = RubyDetectVersion.new(
+        metadata: metadata,
         gemfile_dir: @app_dir,
         buildpack_ruby_path: Pathname.new(buildpack_ruby_path),
         bundler_path: @bundler_install_dir.join("bin/bundle")

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -33,7 +33,12 @@ RSpec.describe "metadata" do
         out = engine.fetch(:lol) do
           "haha"
         end
+        expect(out).to eq("haha")
+        expect(engine.get(:lol)).to eq("haha")
 
+        out = engine.fetch(:lol) do
+          "hehe"
+        end
         expect(out).to eq("haha")
         expect(engine.get(:lol)).to eq("haha")
       end
@@ -53,7 +58,12 @@ RSpec.describe "metadata" do
         out = engine.fetch(:lol) do
           "haha"
         end
+        expect(out).to eq("haha")
+        expect(engine.get(:lol)).to eq("haha")
 
+        out = engine.fetch(:lol) do
+          "hehe"
+        end
         expect(out).to eq("haha")
         expect(engine.get(:lol)).to eq("haha")
 
@@ -81,7 +91,12 @@ RSpec.describe "metadata" do
         out = engine.fetch(:lol) do
           "haha"
         end
+        expect(out).to eq("haha")
+        expect(engine.get(:lol)).to eq("haha")
 
+        out = engine.fetch(:lol) do
+          "hehe"
+        end
         expect(out).to eq("haha")
         expect(engine.get(:lol)).to eq("haha")
 


### PR DESCRIPTION
When a customer depends on a default ruby version they don't want the app to suddenly break between builds. To help with this we make the version "sticky" by persisting the default version to the metadata store and using that value if present instead of the stated default.
