### PR TITLE
Warn on default ruby usage

### DIFF
--- a/lib/heroku_buildpack_ruby.rb
+++ b/lib/heroku_buildpack_ruby.rb
@@ -53,6 +53,7 @@ module HerokuBuildpackRuby
       export_path: export,
       profile_d_path: profile_d_path,
     )
+    user_comms.close
   end
 
   def self.build_cnb(layers_dir: , platform_dir: , env_dir: , plan: , app_dir: , buildpack_ruby_path:)
@@ -85,5 +86,6 @@ module HerokuBuildpackRuby
     EnvProxy.write_layers(
       layers_dir: layers_dir
     )
+    user_comms.close
   end
 end

--- a/lib/heroku_buildpack_ruby/prepare_app_bundler_and_ruby.rb
+++ b/lib/heroku_buildpack_ruby/prepare_app_bundler_and_ruby.rb
@@ -35,7 +35,7 @@ module HerokuBuildpackRuby
     private; attr_reader :user_comms, :vendor_dir, :app_dir, :ruby_install_dir, :bundler_install_dir, :bundler_detect_version, :ruby_detect_version; public
     public; attr_reader :gem_install_dir
 
-    def initialize(vendor_dir: , app_dir: , buildpack_ruby_path: , user_comms: UserComms::V2.new, metadata: MetadataNull.new)
+    def initialize(vendor_dir: , app_dir: , buildpack_ruby_path: , user_comms: UserComms::Null.new, metadata: MetadataNull.new)
       @app_dir = Pathname.new(app_dir)
       @metadata = metadata
       @vendor_dir = Pathname.new(vendor_dir)
@@ -51,6 +51,7 @@ module HerokuBuildpackRuby
 
       @ruby_detect_version = RubyDetectVersion.new(
         metadata: metadata,
+        user_comms: user_comms,
         gemfile_dir: @app_dir,
         buildpack_ruby_path: Pathname.new(buildpack_ruby_path),
         bundler_path: @bundler_install_dir.join("bin/bundle")

--- a/lib/heroku_buildpack_ruby/user_comms.rb
+++ b/lib/heroku_buildpack_ruby/user_comms.rb
@@ -23,6 +23,12 @@ module HerokuBuildpackRuby
       io.puts "-----> #{message}"
     end
 
+    def close
+      @warnings.each do |message|
+        warn_now(message)
+      end
+    end
+
     def warn_later(message)
       @warnings << message
     end
@@ -56,5 +62,11 @@ module HerokuBuildpackRuby
 
   # Like V2 output, but meant for the CNB interface
   class UserComms::CNB < UserComms::V2
+  end
+
+  class UserComms::Null < UserComms::V2
+    def initialize(io = StringIO.new)
+      super
+    end
   end
 end

--- a/spec/unit/ruby_detect_version_spec.rb
+++ b/spec/unit/ruby_detect_version_spec.rb
@@ -57,10 +57,12 @@ RSpec.describe "detect ruby version" do
       FileUtils.touch("#{dir}/Gemfile.lock")
       FileUtils.touch("#{dir}/Gemfile")
 
+      user_comms = HerokuBuildpackRuby::UserComms::Null.new
       ruby_version = HerokuBuildpackRuby::RubyDetectVersion.new(
-        buildpack_ruby_path: which_ruby,
+        user_comms: user_comms,
+        gemfile_dir: dir,
         bundler_path: which_bundle,
-        gemfile_dir: dir
+        buildpack_ruby_path: which_ruby,
       )
 
       # We need a clean environment, we don't want to run bundler inside of another bundler
@@ -68,6 +70,9 @@ RSpec.describe "detect ruby version" do
         ruby_version.call
         expect(ruby_version.version).to eq(HerokuBuildpackRuby::RubyDetectVersion::DEFAULT)
       end
+
+      user_comms.close
+      expect(user_comms.io.string).to include("You have not declared a Ruby version in your Gemfile")
     end
   end
 


### PR DESCRIPTION
When someone is using the default version of Ruby let them know that we think they should be explicit about it with a warning.

This commit also introduces UserComms#close as an explicit point when warnings that have been saved for later can be emitted