### PR TITLE
[changelog skip] Cache bundler (gems) dependencies

### DIFF
--- a/lib/heroku_buildpack_ruby/cache_copy.rb
+++ b/lib/heroku_buildpack_ruby/cache_copy.rb
@@ -1,0 +1,40 @@
+module HerokuBuildpackRuby
+  # Copy the cache from one location to another
+  #
+  # With CNB layers dir is available at runtime with V2 cache contents must be coppied
+  #
+  # Example:
+  #
+  #   cache_dir = Pathname.new("/tmp/cache")
+  #   dest_dir = Pathname.new("/tmp/foo")
+
+  #   puts cache_dir.join("hello.txt").exist? # => false
+  #
+  #   CacheCopy.new(cache_dir: cache_dir, dest_dir: dest_dir).call do
+  #     dest_dir.join("hello.txt").write "hello world")
+  #   end
+  #
+  #   puts cache_dir.join("hello.txt").exist? # => true
+  #
+  #   different_dest_dir = Pathname.new("/tmp/bar")
+  #   puts different_dest_dir.join("hello.txt").exist? # => false
+  #
+  #   CacheCopy.new(cache_dir: cache_dir, dest_dir: different_dest_dir).call do
+  #     puts different_dest_dir.join("hello.txt").exist? # => true
+  #   end
+  class CacheCopy
+    def initialize(cache_dir: , dest_dir:)
+      @cache_dir = Pathname.new(cache_dir).tap(&:mkpath)
+      @dest_dir = Pathname.new(dest_dir).tap(&:mkpath)
+    end
+
+    def call
+      raise "nope" unless block_given?
+
+      # https://ruby-doc.org/stdlib-2.7.2/libdoc/fileutils/rdoc/FileUtils.html#method-c-cp_r
+      FileUtils.cp_r(@cache_dir.glob("*"), @dest_dir)
+      yield @dest_dir
+      FileUtils.cp_r(@dest_dir.glob("*"), @cache_dir)
+    end
+  end
+end

--- a/lib/heroku_buildpack_ruby/user_comms.rb
+++ b/lib/heroku_buildpack_ruby/user_comms.rb
@@ -35,22 +35,24 @@ module HerokuBuildpackRuby
     end
 
     def warn_now(message)
-      io.puts "## Warning"
-      io.puts
-      io.puts(message)
+      self.puts
+      self.puts "## Warning"
+      self.puts
+      self.puts(message)
+      self.puts
     end
 
     def error_and_exit(message)
-      io.puts "\e[1m\e[31m" # Bold Red
-      io.puts " !"
+      self.puts "\e[1m\e[31m" # Bold Red
+      self.puts " !"
       message.split("\n").each do |line|
-        Kernel.puts " !     #{line.strip}"
+        io.puts " !     #{line.strip}"
       end
-      io.puts " !\e[0m"
+      self.puts " !\e[0m"
       exit(1)
     end
 
-    def puts(message)
+    def puts(message = "")
       message.to_s.each_line do |line|
         if line.end_with?("\n".freeze)
           io.print "       #{line}"

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -12,7 +12,13 @@ RSpec.describe "This buildpack" do
       app.deploy do
         # Assert the behavior you desire here
         expect(app.output).to match("deployed to Heroku")
+        expect(app.output).to match("Installing rake")
         expect(app.run("ruby -v")).to match("2.6.6")
+
+        app.commit!
+        app.push!
+
+        expect(app.output).to match("Using rake")
       end
     end
   end

--- a/spec/unit/cache_copy_spec.rb
+++ b/spec/unit/cache_copy_spec.rb
@@ -7,20 +7,19 @@ RSpec.describe "cache copy" do
       dest_dir = dir.join("foo").tap(&:mkpath)
       cache_dir = dir.join("cache").tap(&:mkpath)
 
-      expect(dest_dir.entries.map(&:to_s)).to eq([".", ".."])
-
+      expect(dest_dir).to be_empty
       HerokuBuildpackRuby::CacheCopy.new(cache_dir: cache_dir, dest_dir: dest_dir).call do |block_value|
         dest_dir.join("hello.txt").write "hello world"
+
         expect(dest_dir.entries.map(&:to_s)).to include("hello.txt")
         expect(dest_dir).to eq(block_value)
       end
-
       expect(dest_dir.entries.map(&:to_s)).to include("hello.txt")
       expect(cache_dir.entries.map(&:to_s)).to include("hello.txt")
 
       different_dest_dir = dir.join("bar").tap(&:mkpath)
-      expect(different_dest_dir.entries.map(&:to_s)).to_not include("hello.txt")
 
+      expect(different_dest_dir).to be_empty
       HerokuBuildpackRuby::CacheCopy.new(cache_dir: cache_dir, dest_dir: different_dest_dir).call do
         expect(different_dest_dir.entries.map(&:to_s)).to include("hello.txt")
       end

--- a/spec/unit/cache_copy_spec.rb
+++ b/spec/unit/cache_copy_spec.rb
@@ -1,0 +1,29 @@
+require_relative "../spec_helper.rb"
+
+RSpec.describe "cache copy" do
+  it "" do
+    Dir.mktmpdir do |dir|
+      dir = Pathname.new(dir)
+      dest_dir = dir.join("foo").tap(&:mkpath)
+      cache_dir = dir.join("cache").tap(&:mkpath)
+
+      expect(dest_dir.entries.map(&:to_s)).to eq([".", ".."])
+
+      HerokuBuildpackRuby::CacheCopy.new(cache_dir: cache_dir, dest_dir: dest_dir).call do |block_value|
+        dest_dir.join("hello.txt").write "hello world"
+        expect(dest_dir.entries.map(&:to_s)).to include("hello.txt")
+        expect(dest_dir).to eq(block_value)
+      end
+
+      expect(dest_dir.entries.map(&:to_s)).to include("hello.txt")
+      expect(cache_dir.entries.map(&:to_s)).to include("hello.txt")
+
+      different_dest_dir = dir.join("bar").tap(&:mkpath)
+      expect(different_dest_dir.entries.map(&:to_s)).to_not include("hello.txt")
+
+      HerokuBuildpackRuby::CacheCopy.new(cache_dir: cache_dir, dest_dir: different_dest_dir).call do
+        expect(different_dest_dir.entries.map(&:to_s)).to include("hello.txt")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## CNB Cache

This is so easy it's a joke. Use the layers dir to install gems. It's literally that easy. The bulk of the work here was to change my CNB model to allow re-deploying the same app.

## V2 Cache


The challenge with implementing this in V2 is the location of the cache is not present in run and build time. What this means is that we end up needing to copy the contents of the cache directory to the location where the gems will end up living before install, and then copy them back after the install. This was accomplished by introducing a "cache copy" object with an interface that wraps another action.