### PR TITLE
[ci skip] Teach the Ruby buildpack to run other buildpacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ references:
     run:
       name: Run test suite
       command: PARALLEL_SPLIT_TEST_PROCESSES="4" IS_RUNNING_ON_CI=1 bundle exec parallel_split_test spec/cnb
+  docker_commands: &docker_commands
+    run:
+      name: Run test suite
+      command: PARALLEL_SPLIT_TEST_PROCESSES="4" IS_RUNNING_ON_CI=1 bundle exec parallel_split_test spec/docker
   unit: &unit
     run:
       name: Run test suite
@@ -69,12 +73,23 @@ jobs:
       - ruby/install-deps
       - <<: *hatchet_setup
       - <<: *pack_cnb
+  docker_commands:
+    machine: true
+    steps:
+      - checkout
+      - pack/install-pack
+      - ruby/install:
+          version: '2.7'
+      - ruby/install-deps
+      - <<: *hatchet_setup
+      - <<: *docker_commands
 
 workflows:
   version: 2
   build:
     jobs:
-      - "unit"
-      - "hatchet"
-      - "pack_cnb"
+      - unit
+      - hatchet
+      - pack_cnb
+      - docker_commands
 

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -102,3 +102,65 @@ buildpack_ruby_path()
 {
   echo $BUILDPACK_DIR/vendor/ruby/$STACK/bin/ruby
 }
+
+
+compile_buildpack_v2()
+{
+  BUILD_DIR=$1
+  CACHE_DIR=$2
+  ENV_DIR=$3
+  BUILDPACK=$4
+  NAME=$5
+
+  dir=$(mktemp -t buildpackXXXXX)
+  rm -rf $dir
+
+  url=${BUILDPACK%#*}
+  branch=${BUILDPACK#*#}
+
+  if [ "$branch" == "$url" ]; then
+    branch=""
+  fi
+
+  if [ "$url" != "" ]; then
+    echo "=====> Downloading Buildpack: ${NAME}"
+
+    if [[ "$url" =~ \.tgz$ ]] || [[ "$url" =~ \.tgz\? ]]; then
+      mkdir -p "$dir"
+      curl -s "$url" | tar xvz -C "$dir" >/dev/null 2>&1
+    else
+      git clone $url $dir >/dev/null 2>&1
+    fi
+    cd $dir
+
+    if [ "$branch" != "" ]; then
+      git checkout $branch >/dev/null 2>&1
+    fi
+
+    # we'll get errors later if these are needed and don't exist
+    chmod -f +x $dir/bin/{detect,compile,release} || true
+
+    framework=$($dir/bin/detect $1)
+
+    if [ $? == 0 ]; then
+      echo "=====> Detected Framework: $framework"
+      $dir/bin/compile $1 $2 $3
+
+      if [ $? != 0 ]; then
+        exit 1
+      fi
+
+      # check if the buildpack left behind an environment for subsequent ones
+      if [ -e $dir/export ]; then
+        source $dir/export
+      fi
+
+      if [ -x $dir/bin/release ]; then
+        $dir/bin/release $1 > $1/last_pack_release.out
+      fi
+    else
+      echo "Couldn't detect any framework for this buildpack. Exiting."
+      exit 1
+    fi
+  fi
+}

--- a/hatchet.json
+++ b/hatchet.json
@@ -3,7 +3,8 @@
     "sharpstone/default_ruby"
   ],
   "node_apps": [
-    "heroku/node-js-getting-started"
+    "heroku/node-js-getting-started",
+    "sharpstone/minimal_webpacker"
   ],
   "python_apps": [
     "heroku/python-getting-started"

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -1,4 +1,6 @@
 ---
+- - "./repos/node_apps/minimal_webpacker"
+  - bca8b8169c553a0f62f0263b621cf3a5813e4023
 - - "./repos/node_apps/node-js-getting-started"
   - a5d0ca5a618f18948652ebbd20b27b6970293d5c
 - - "./repos/python_apps/python-getting-started"

--- a/spec/docker/bash_functions_spec.rb
+++ b/spec/docker/bash_functions_spec.rb
@@ -1,0 +1,46 @@
+require_relative "../spec_helper.rb"
+
+RSpec.describe "bash_functions.sh that need docker" do
+  it "compiles node apps" do
+    Hatchet::Runner.new("minimal_webpacker").tap do |app|
+      app.in_directory do
+        contents = <<~EOM
+          #! /usr/bin/env bash
+          set -eu
+
+          cd /myapp
+          export STACK="heroku-18"
+
+          #{bash_functions_file.read}
+
+          build_dir="$PWD"
+          cache_dir="/tmp/cache_dir"
+          env_dir="/tmp/env_dir"
+
+          mkdir -p "$cache_dir"
+          mkdir -p "$env_dir"
+
+          compile_buildpack_v2 "$build_dir" "$cache_dir" "$env_dir" "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/nodejs.tgz" "heroku/nodejs"
+
+          echo "which node $(which node)"
+          echo "which yarn $(which yarn)"
+        EOM
+
+        script = Pathname.new(".").join("script.sh")
+        script.write(contents)
+        FileUtils.chmod("+x", script)
+
+        output = `docker run -v "$PWD:/myapp" -it --rm heroku/heroku:18-build /myapp/script.sh 2>&1`
+
+        expect(output).to include("Build succeeded")
+        expect(output).to include("installing node")
+        expect(output).to include("installing yarn")
+
+        expect(output).to include("which node /myapp/.heroku/node/bin/node")
+        expect(output).to include("which yarn /myapp/.heroku/yarn/bin/yarn")
+
+        expect($?.success?).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/docker/bash_functions_spec.rb
+++ b/spec/docker/bash_functions_spec.rb
@@ -2,45 +2,43 @@ require_relative "../spec_helper.rb"
 
 RSpec.describe "bash_functions.sh that need docker" do
   it "compiles node apps" do
-    Hatchet::Runner.new("minimal_webpacker").tap do |app|
-      app.in_directory do
-        contents = <<~EOM
-          #! /usr/bin/env bash
-          set -eu
+    Hatchet::Runner.new("minimal_webpacker").in_directory do
+      contents = <<~EOM
+        #! /usr/bin/env bash
+        set -eu
+        export STACK="heroku-18"
 
-          cd /myapp
-          export STACK="heroku-18"
+        #{bash_functions_file.read}
 
-          #{bash_functions_file.read}
 
-          build_dir="$PWD"
-          cache_dir="/tmp/cache_dir"
-          env_dir="/tmp/env_dir"
+        build_dir="/tmp/build_dir"
+        cache_dir="/tmp/cache_dir"
+        env_dir="/tmp/env_dir"
 
-          mkdir -p "$cache_dir"
-          mkdir -p "$env_dir"
+        mkdir -p "$cache_dir"
+        mkdir -p "$env_dir"
+        mkdir -p "$build_dir"
+        cp -r /myapp/* "$build_dir"
 
-          compile_buildpack_v2 "$build_dir" "$cache_dir" "$env_dir" "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/nodejs.tgz" "heroku/nodejs"
+        compile_buildpack_v2 "$build_dir" "$cache_dir" "$env_dir" "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/nodejs.tgz" "heroku/nodejs"
 
-          echo "which node $(which node)"
-          echo "which yarn $(which yarn)"
-        EOM
+        echo "which node $(which node)"
+        echo "which yarn $(which yarn)"
+      EOM
 
-        script = Pathname.new(".").join("script.sh")
-        script.write(contents)
-        FileUtils.chmod("+x", script)
+      script = Pathname.new(".").join("script.sh")
+      script.write(contents)
+      FileUtils.chmod("+x", script)
 
-        output = `docker run -v "$PWD:/myapp" -it --rm heroku/heroku:18-build /myapp/script.sh 2>&1`
+      output = `docker run -v "$PWD:/myapp" -it --rm heroku/heroku:18-build /myapp/script.sh 2>&1`
+      expect(output).to include("Build succeeded")
+      expect(output).to include("installing node")
+      expect(output).to include("installing yarn")
 
-        expect(output).to include("Build succeeded")
-        expect(output).to include("installing node")
-        expect(output).to include("installing yarn")
+      expect(output).to include("which node /tmp/build_dir/.heroku/node/bin/node")
+      expect(output).to include("which yarn /tmp/build_dir/.heroku/yarn/bin/yarn")
 
-        expect(output).to include("which node /myapp/.heroku/node/bin/node")
-        expect(output).to include("which yarn /myapp/.heroku/yarn/bin/yarn")
-
-        expect($?.success?).to be_truthy
-      end
+      expect($?.success?).to be_truthy
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require "heroku_buildpack_ruby"
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+  config.display_try_failure_messages = true
   config.verbose_retry       = true # show retry status in spec process
   config.default_retry_count = 2 if ENV['IS_RUNNING_ON_CI'] # retry all tests that fail again
 
@@ -89,6 +90,10 @@ end
 
 def hatchet_path(path = "")
   Pathname.new(__FILE__).join("../../repos").expand_path.join(path)
+end
+
+def bash_functions_file
+  root_dir.join("bin", "support", "bash_functions.sh")
 end
 
 def isolate_in_fork

--- a/spec/unit/bash_functions_spec.rb
+++ b/spec/unit/bash_functions_spec.rb
@@ -4,10 +4,6 @@ require_relative "../spec_helper.rb"
 # Log ENV setting and getting
 #
 RSpec.describe "bash_functions.sh" do
-  def bash_functions_file
-    root_dir.join("bin", "support", "bash_functions.sh")
-  end
-
   def exec_with_bash_functions(code, stack: "heroku-18")
     contents = <<~EOM
       #! /usr/bin/env bash


### PR DESCRIPTION
The goal is to use the Node buildpack to install node and yarn binaries instead of manually installing them ourselves. This is the first step.