### PR TITLE
[changelog skip] Install node via CNB plan

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,20 +1,35 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+# == V2 interface
 
 if [ -z "$CNB_STACK_ID" ]; then
-  # v2 API
   APP_DIR=$1
-else
-  PLATFORM_DIR=$1
-  PLAN=$2
-  # working is the cwd now
-  # v3 API
-  APP_DIR=$(pwd)
+
+  if [ ! -f "$APP_DIR/Gemfile" ]; then
+    echo "no"
+    exit 1
+  else
+    echo "ruby"
+    exit 0
+  fi
 fi
 
-if [ -f "$APP_DIR/Gemfile" ]; then
-  echo "Ruby"
-  exit 0
-else
+# == CNB Interface
+
+set -eu
+PLAN=$2
+APP_DIR=$(pwd)
+
+if [ ! -f "$APP_DIR/Gemfile" ]; then
   echo "no"
   exit 1
+else
+  echo "Ruby"
 fi
+
+BIN_DIR=$(cd "$(dirname "$0")"; pwd)
+source "$BIN_DIR/support/bash_functions.sh"
+
+write_to_build_plan "$PLAN" "$APP_DIR"
+
+exit 0

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -202,7 +202,7 @@ write_to_build_plan_ruby_node()
 
 cat << EOF > "$build_plan"
 [[provides]]
-name = "ruby"u
+name = "ruby"
 
 [[requires]]
 name = "node"

--- a/lib/heroku_buildpack_ruby/toml.rb
+++ b/lib/heroku_buildpack_ruby/toml.rb
@@ -21,6 +21,8 @@ module HerokuBuildpackRuby
   module TOML
     def self.load(string)
       Tomlrb.parse(string, symbolize_keys: true)
+    rescue Tomlrb::ParseError => e
+      raise e, "#{e.message}\n\nCould not parse TOML input. Input:\n\n#{string}"
     end
 
     def self.dump(hash)

--- a/spec/cnb/buildpack_spec.rb
+++ b/spec/cnb/buildpack_spec.rb
@@ -96,4 +96,23 @@ RSpec.describe "Cloud Native Buildpack" do
       expect(app.output).to include("Using rake")
     end
   end
+
+  it "installs node and yarn" do
+    CnbRun.new(hatchet_path("ruby_apps/minimal_webpacker"), buildpack_paths: ["heroku/nodejs", buildpack_path]).call do |app|
+      puts app.output
+      expect(app.output).to include("Installing rake")
+
+      expect(app.output).to include("Installing yarn")
+
+      app.run_multi!("which node") do |out, status|
+        expect(out.strip).to_not be_empty
+        expect(status.success?).to be_truthy
+      end
+
+      app.run_multi!("which yarn") do |out, status|
+        expect(out.strip).to_not be_empty
+        expect(status.success?).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/unit/bash_functions_spec.rb
+++ b/spec/unit/bash_functions_spec.rb
@@ -124,10 +124,10 @@ RSpec.describe "bash_functions.sh" do
         write_to_build_plan "#{plan_path}" "#{build_dir}"
       EOM
 
-      expect(plan_path.read).to include(%Q{[[provides]]\nname = "ruby"})
-      expect(plan_path.read).to include(%Q{[[requires]]\nname = "ruby"})
+      toml = HerokuBuildpackRuby::TOML.load(plan_path.read)
 
-      expect(plan_path.read).to include(%Q{[[requires]]\nname = "node"})
+      expect(toml).to include(provides: [{name: "ruby"}])
+      expect(toml).to include(requires: [{name: "node"}, {name: "ruby"}])
     end
   end
 
@@ -149,10 +149,10 @@ RSpec.describe "bash_functions.sh" do
         write_to_build_plan "#{plan_path}" "#{build_dir}"
       EOM
 
-      expect(plan_path.read).to include(%Q{[[provides]]\nname = "ruby"})
-      expect(plan_path.read).to include(%Q{[[requires]]\nname = "ruby"})
+      toml = HerokuBuildpackRuby::TOML.load(plan_path.read)
 
-      expect(plan_path.read).to_not include(%Q{[[requires]]\nname = "node"})
+      expect(toml).to include(provides: [{name: "ruby"}])
+      expect(toml).to include(requires: [{name: "ruby"}])
     end
   end
 
@@ -165,8 +165,10 @@ RSpec.describe "bash_functions.sh" do
         write_to_build_plan "#{plan_path}" "#{build_dir}"
       EOM
 
-      expect(plan_path.read).to include(%Q{[[provides]]\nname = "ruby"})
-      expect(plan_path.read).to include(%Q{[[requires]]\nname = "ruby"})
+      toml = HerokuBuildpackRuby::TOML.load(plan_path.read)
+
+      expect(toml).to include(provides: [{name: "ruby"}])
+      expect(toml).to include(requires: [{name: "ruby"}])
     end
   end
 end


### PR DESCRIPTION
By requiring a name that we do not provide in the buildpack plan https://github.com/buildpacks/spec/blob/main/buildpack.md#build-plan-toml we're essentially telling our build system that we need node to run before Ruby.

There is a failing pack/cnb test. I believe it's failing because my copy of pack does not know about github.com/heroku/nodejs-engine-buildpack and I'm not sure how to let it know.

In addition, I'm not sure if we can provide a better debugging experience here. When this fails it looks like this:

```
     RuntimeError:
       Command "pack build minimal-heroku-buildpack-ruby-tests:d35c175ee32726c841bc68be474a941c --path /Users/rschneeman/Documents/projects/work/minimal-ruby/repos/ruby_apps/minimal_webpacker --builder heroku/buildpacks:18 --buildpack /Users/rschneeman/Documents/projects/work/minimal-ruby" failed. Output: 18: Pulling from heroku/buildpacks
       Digest: sha256:bd838893fbdbf74b8e6038aefa8a198d6691d560144e9a3d2460cd3bb2003d02
       Status: Image is up to date for heroku/buildpacks:18
       18: Pulling from heroku/pack
       Digest: sha256:c8fffd202d2c6c5a89538c3c98e96ceb1aac678d5ccccadd73bc6cb3a1c78346
       Status: Image is up to date for heroku/pack:18
       ===> DETECTING
       ERROR: No buildpack groups passed detection.
       ERROR: Please check that you are running against the correct path.
       ERROR: failed to detect: no buildpacks participating
       ERROR: failed to build: executing lifecycle: failed with status code: 100
```

Which is not correct. It found a matching buildpack, but that buildpack gave it a plan that it cannot satisfy. This message can be improved in pack so that it explains which buildpack(s) were detected as well as listing off what requirements could not be met.