### PR TITLE
[changelog skip] Don't re-allocate Pathname

### DIFF
--- a/lib/buildpack.rb
+++ b/lib/buildpack.rb
@@ -2,7 +2,7 @@ require_relative "system_bootstrap"
 
 module Buildpack
   def self.compile(build_dir: , cache_dir:, env_dir: , buildpack_ruby_path:)
-    app_dir = Pathname.new(build_dir)
+    app_dir = Pathname(build_dir)
     vendor_dir = app_dir.join(".heroku/ruby")
     profile_d_dir = app_dir.join(".profile.d/ruby.sh")
 

--- a/lib/heroku_buildpack_ruby.rb
+++ b/lib/heroku_buildpack_ruby.rb
@@ -15,15 +15,15 @@ require_relative "heroku_buildpack_ruby/metadata.rb"
 #   HerokuBuildpackRuby.build_cnb(...)
 #
 module HerokuBuildpackRuby
-  BUILDPACK_DIR = Pathname.new(__dir__).join("..")
+  BUILDPACK_DIR = Pathname(__dir__).join("..")
   EnvProxy.register_layer(:gems,    build: true, cache: true,  launch: true)
   EnvProxy.register_layer(:bundler, build: true, cache: false, launch: true)
   EnvProxy.register_layer(:ruby,    build: true, cache: false, launch: true)
 
   def self.compile_legacy(build_dir: , cache_dir:, env_dir: , buildpack_ruby_path:)
     export = BUILDPACK_DIR.join("export")
-    app_dir = Pathname.new(build_dir)
-    cache_dir = Pathname.new(cache_dir)
+    app_dir = Pathname(build_dir)
+    cache_dir = Pathname(cache_dir)
     vendor_dir = app_dir.join(".heroku/ruby")
     metadata_dir = cache_dir.join("vendor/heroku")
     profile_d_path = app_dir.join(".profile.d/ruby.sh")
@@ -64,8 +64,8 @@ module HerokuBuildpackRuby
   end
 
   def self.build_cnb(layers_dir: , platform_dir: , env_dir: , plan: , app_dir: , buildpack_ruby_path:)
-    app_dir = Pathname.new(app_dir)
-    layers_dir = Pathname.new(layers_dir)
+    app_dir = Pathname(app_dir)
+    layers_dir = Pathname(layers_dir)
     vendor_dir = app_dir.join(".heroku/ruby")
     gems_install_dir = layers_dir.join("gems")
 

--- a/lib/heroku_buildpack_ruby/bundle_install.rb
+++ b/lib/heroku_buildpack_ruby/bundle_install.rb
@@ -12,10 +12,10 @@ module HerokuBuildpackRuby
 
     def initialize(app_dir: , bundle_without_default: , bundle_install_gems_dir:, user_comms: , metadata: Metadata::Null.new)
       @user_comms = user_comms
-      @app_dir = Pathname.new(app_dir)
+      @app_dir = Pathname(app_dir)
       @metadata = metadata
       @bundle_without_default = bundle_without_default
-      @bundle_install_gems_dir = Pathname.new(bundle_install_gems_dir)
+      @bundle_install_gems_dir = Pathname(bundle_install_gems_dir)
       @bundle_gems_binsub_dir = @bundle_install_gems_dir.join("bin")
       @bundle_output = nil
     end

--- a/lib/heroku_buildpack_ruby/bundler_detect_version.rb
+++ b/lib/heroku_buildpack_ruby/bundler_detect_version.rb
@@ -23,7 +23,7 @@ module HerokuBuildpackRuby
     private; attr_reader :lockfile_path; public;
 
     def initialize(lockfile_path: )
-      @lockfile_path = Pathname.new(lockfile_path)
+      @lockfile_path = Pathname(lockfile_path)
       @version = nil
     end
 

--- a/lib/heroku_buildpack_ruby/bundler_download.rb
+++ b/lib/heroku_buildpack_ruby/bundler_download.rb
@@ -17,7 +17,7 @@ module HerokuBuildpackRuby
     public; attr_reader :version
 
     def initialize(version:, install_dir: , user_comms: UserComms::Null.new, metadata: Metadata::Null.new)
-      @install_dir = Pathname.new(install_dir).tap(&:mkpath)
+      @install_dir = Pathname(install_dir).tap(&:mkpath)
       @user_comms = user_comms
       @metadata = metadata.layer(:bundler)
       @version = version

--- a/lib/heroku_buildpack_ruby/bundler_lockfile_parser.rb
+++ b/lib/heroku_buildpack_ruby/bundler_lockfile_parser.rb
@@ -10,8 +10,8 @@ module HerokuBuildpackRuby
     private; attr_reader :parser, :gemfile_lock_path, :bundler_install_dir; public
 
     def initialize(gemfile_lock_path: , bundler_install_dir: )
-      @bundler_install_dir = Pathname.new(bundler_install_dir)
-      @gemfile_lock_path = Pathname.new(gemfile_lock_path)
+      @bundler_install_dir = Pathname(bundler_install_dir)
+      @gemfile_lock_path = Pathname(gemfile_lock_path)
       @platforms = nil
       @gem_specs = nil
       @parser = nil

--- a/lib/heroku_buildpack_ruby/bundler_strip_bundled_with.rb
+++ b/lib/heroku_buildpack_ruby/bundler_strip_bundled_with.rb
@@ -20,7 +20,7 @@ module HerokuBuildpackRuby
   #
   # Example:
   #
-  #   lockfile = Pathname.new("Gemfile.lock")
+  #   lockfile = Pathname("Gemfile.lock")
   #   puts lockfile.include?("BUNDLED WITH") # => true
   #   BundlerStripBundledWith.new(lockfile).call
   #   puts lockfile.include?("BUNDLED WITH") # => false
@@ -31,7 +31,7 @@ module HerokuBuildpackRuby
 
     def initialize(lockfile_path: , user_comms: UserComms::Null.new)
       @user_comms = user_comms
-      @lockfile_path = Pathname.new(lockfile_path)
+      @lockfile_path = Pathname(lockfile_path)
     end
 
     def call

--- a/lib/heroku_buildpack_ruby/cache_copy.rb
+++ b/lib/heroku_buildpack_ruby/cache_copy.rb
@@ -5,8 +5,8 @@ module HerokuBuildpackRuby
   #
   # Example:
   #
-  #   cache_dir = Pathname.new("/tmp/cache")
-  #   dest_dir = Pathname.new("/tmp/foo")
+  #   cache_dir = Pathname("/tmp/cache")
+  #   dest_dir = Pathname("/tmp/foo")
 
   #   puts cache_dir.join("hello.txt").exist? # => false
   #
@@ -16,7 +16,7 @@ module HerokuBuildpackRuby
   #
   #   puts cache_dir.join("hello.txt").exist? # => true
   #
-  #   different_dest_dir = Pathname.new("/tmp/bar")
+  #   different_dest_dir = Pathname("/tmp/bar")
   #   puts different_dest_dir.join("hello.txt").exist? # => false
   #
   #   CacheCopy.new(cache_dir: cache_dir, dest_dir: different_dest_dir).call do
@@ -24,8 +24,8 @@ module HerokuBuildpackRuby
   #   end
   class CacheCopy
     def initialize(cache_dir: , dest_dir:)
-      @cache_dir = Pathname.new(cache_dir).tap(&:mkpath)
-      @dest_dir = Pathname.new(dest_dir).tap(&:mkpath)
+      @cache_dir = Pathname(cache_dir).tap(&:mkpath)
+      @dest_dir = Pathname(dest_dir).tap(&:mkpath)
     end
 
     def call

--- a/lib/heroku_buildpack_ruby/curl_fetch.rb
+++ b/lib/heroku_buildpack_ruby/curl_fetch.rb
@@ -23,7 +23,7 @@ module HerokuBuildpackRuby
     attr_reader :url
 
     def initialize(path, install_dir: , host_url: VENDOR_HOST_URL, folder: ENV["STACK"])
-      @url = Pathname.new(host_url).join(folder.to_s).join(path)
+      @url = Pathname(host_url).join(folder.to_s).join(path)
       @install_dir = install_dir
 
       # TODO support CURL_TIMEOUT and CURL_CONNECT_TIMEOUT

--- a/lib/heroku_buildpack_ruby/env_proxy.rb
+++ b/lib/heroku_buildpack_ruby/env_proxy.rb
@@ -25,7 +25,7 @@ module HerokuBuildpackRuby
   # Later when all layers are written to we can expect to see this environment variable set in the layers dir
   # via the `EnvProxy.write_layers` method:
   #
-  #   layers_dir = Pathname.new(layers_dir)
+  #   layers_dir = Pathname(layers_dir)
   #   EnvProxy.write_layers(layers_dir: layers_dir)
   #
   #   puts layers_dir.join("ruby/launch.env").entries # => "PATH"
@@ -37,8 +37,8 @@ module HerokuBuildpackRuby
   # To write to an export file such as profile.d script or a bash profile you can use the `EnvProxy.export_to` interface
   # which support v2/legacy:
   #
-  #   ruby_sh = Pathname.new("/app").join(".profile.d/ruby.sh")
-  #   export = Pathname.new(BUILDPACK_PATH).join("export")
+  #   ruby_sh = Pathname("/app").join(".profile.d/ruby.sh")
+  #   export = Pathname(BUILDPACK_PATH).join("export")
   #
   #   EnvProxy.export_to(profile_d_path: ruby_sh, export_path: export_path, app_dir: "/app")
   #
@@ -173,8 +173,8 @@ module HerokuBuildpackRuby
     # Top level interface for exporting env vars for profiled
     # and export file to other buildpacks
     def self.export(profile_d_path: , export_path: , app_dir: )
-      profile_d_path = Pathname.new(profile_d_path).tap {|p| p.dirname.mkpath }
-      export_path = Pathname.new(export_path)
+      profile_d_path = Pathname(profile_d_path).tap {|p| p.dirname.mkpath }
+      export_path = Pathname(export_path)
 
       @env_array.each do |env|
         env.write_exports(
@@ -188,7 +188,7 @@ module HerokuBuildpackRuby
     # Used to wrote all ENV vars to their correct env files
     # with cloud native buildpacks
     def self.write_layers(layers_dir: )
-      layers_dir = Pathname.new(layers_dir)
+      layers_dir = Pathname(layers_dir)
 
       @registered_layers.each do |name, config|
         contents = TOML::Dumper.new(config).to_s

--- a/lib/heroku_buildpack_ruby/env_proxy/base.rb
+++ b/lib/heroku_buildpack_ruby/env_proxy/base.rb
@@ -108,7 +108,7 @@ module HerokuBuildpackRuby
     #   LOL_PATH_ENV.prepend(ruby: "/app/lol")
     #   LOL_PATH_ENV.prepend(gems: "/app/rofl")
     #
-    #   layers_dir = Pathname.new(Dir.mktmpdir)
+    #   layers_dir = Pathname(Dir.mktmpdir)
     #   LOL_PATH.write_exports(
     #     layers_dir: layers_dir
     #   )
@@ -118,7 +118,7 @@ module HerokuBuildpackRuby
     #
     def write_layer(layers_dir: )
       @layer_env_hash.each do |name, v|
-        layer = Pathname.new(layers_dir).join(name.to_s)
+        layer = Pathname(layers_dir).join(name.to_s)
         launch_dir = layer.join("env.launch").tap(&:mkpath)
 
         build_dir = layer.join("env.build").tap(&:mkpath)
@@ -158,8 +158,8 @@ module HerokuBuildpackRuby
     #  puts File.read(export) # => 'export LOL_PATH="/app/rofl:/app/lol:$LOL_PATH"'
     #
     def write_exports(profile_d_path: , export_path: , app_dir: )
-      profile_d_path = Pathname.new(profile_d_path)
-      export_path = Pathname.new(export_path)
+      profile_d_path = Pathname(profile_d_path)
+      export_path = Pathname(export_path)
 
       profile_d_path.open("a") do |f|
         f.write(to_export(replace: app_dir, with: "$HOME"))

--- a/lib/heroku_buildpack_ruby/metadata/cnb.rb
+++ b/lib/heroku_buildpack_ruby/metadata/cnb.rb
@@ -18,7 +18,7 @@ module HerokuBuildpackRuby
     #   # => "a good boy"
     class CNB
       def initialize(dir: ,name:)
-        @store = Pathname.new(dir).join(name.to_s, "store.toml").tap {|p| p.dirname.mkpath; FileUtils.touch(p) }
+        @store = Pathname(dir).join(name.to_s, "store.toml").tap {|p| p.dirname.mkpath; FileUtils.touch(p) }
         read
       end
 

--- a/lib/heroku_buildpack_ruby/metadata/v2.rb
+++ b/lib/heroku_buildpack_ruby/metadata/v2.rb
@@ -18,7 +18,7 @@ module HerokuBuildpackRuby
     #   # => "a good boy"
     class V2
       def initialize(dir: ,name:)
-        @dir = Pathname.new(dir).join(name.to_s).tap(&:mkpath)
+        @dir = Pathname(dir).join(name.to_s).tap(&:mkpath)
         @metadata = {}
 
         @dir.entries.each do |entry|

--- a/lib/heroku_buildpack_ruby/prepare_app_bundler_and_ruby.rb
+++ b/lib/heroku_buildpack_ruby/prepare_app_bundler_and_ruby.rb
@@ -16,7 +16,7 @@ module HerokuBuildpackRuby
   #
   # Example:
   #
-  #   vendor_dir = Pathname.new("/app/.heroku/ruby")
+  #   vendor_dir = Pathname("/app/.heroku/ruby")
   #   prepare = PrepareAppBundlerAndRuby(
   #     vendor_dir: "/app/.heroku/ruby",
   #     app_dir: "/app",
@@ -39,9 +39,9 @@ module HerokuBuildpackRuby
 
     def initialize(vendor_dir: , app_dir: , buildpack_ruby_path: , user_comms: UserComms::Null.new, metadata: Metadata::Null.new, stack: ENV['STACK'])
       @stack = stack
-      @app_dir = Pathname.new(app_dir)
+      @app_dir = Pathname(app_dir)
       @metadata = metadata
-      vendor_dir = Pathname.new(vendor_dir)
+      vendor_dir = Pathname(vendor_dir)
       @user_comms = user_comms
       lockfile_path = @app_dir.join("Gemfile.lock")
       @ruby_install_dir = vendor_dir.join("ruby")
@@ -61,7 +61,7 @@ module HerokuBuildpackRuby
         user_comms: user_comms,
         gemfile_dir: @app_dir,
         bundler_path: @bundler_install_dir.join("bin/bundle"),
-        buildpack_ruby_path: Pathname.new(buildpack_ruby_path),
+        buildpack_ruby_path: Pathname(buildpack_ruby_path),
       )
     end
 

--- a/lib/heroku_buildpack_ruby/ruby_detect_version.rb
+++ b/lib/heroku_buildpack_ruby/ruby_detect_version.rb
@@ -40,11 +40,11 @@ module HerokuBuildpackRuby
     public; attr_reader :version
 
     def initialize(gemfile_dir: , buildpack_ruby_path: , bundler_path: , metadata: Metadata::Null.new, default_version: DEFAULT, user_comms: UserComms::Null.new)
-      gemfile_dir = Pathname.new(gemfile_dir)
-      @bundler_path = Pathname.new(bundler_path)
+      gemfile_dir = Pathname(gemfile_dir)
+      @bundler_path = Pathname(bundler_path)
       @gemfile_path = gemfile_dir.join("Gemfile")
       @lockfile_path = gemfile_dir.join("Gemfile.lock")
-      @buildpack_ruby_path = Pathname.new(buildpack_ruby_path)
+      @buildpack_ruby_path = Pathname(buildpack_ruby_path)
 
       @user_comms = user_comms
       @ruby_metadata = metadata.layer(:ruby)

--- a/lib/heroku_buildpack_ruby/ruby_download.rb
+++ b/lib/heroku_buildpack_ruby/ruby_download.rb
@@ -10,7 +10,7 @@ module HerokuBuildpackRuby
       @stack = stack
       @version = version
       @user_comms = user_comms
-      @install_dir = Pathname.new(install_dir).tap(&:mkpath)
+      @install_dir = Pathname(install_dir).tap(&:mkpath)
 
       raise "Must provide a stack #{@stack} to download a Ruby version" if @stack.to_s.empty?
     end

--- a/spec/docker/bash_functions_spec.rb
+++ b/spec/docker/bash_functions_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "bash_functions.sh that need docker" do
         echo "which yarn $(which yarn)"
       EOM
 
-      script = Pathname.new(".").join("script.sh")
+      script = Pathname(".").join("script.sh")
       script.write(contents)
       FileUtils.chmod("+x", script)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,11 +69,11 @@ def run!(cmd)
 end
 
 def spec_dir
-  Pathname.new(__dir__)
+  Pathname(__dir__)
 end
 
 def root_dir
-  Pathname.new(__dir__).join("..")
+  Pathname(__dir__).join("..")
 end
 
 def which_ruby
@@ -81,7 +81,7 @@ def which_ruby
 end
 
 def which_bundle
-  @which_bundle_dir ||= Pathname.new(`which bundle`.strip)
+  @which_bundle_dir ||= Pathname(`which bundle`.strip)
 end
 
 def buildpack_path
@@ -89,7 +89,7 @@ def buildpack_path
 end
 
 def hatchet_path(path = "")
-  Pathname.new(__FILE__).join("../../repos").expand_path.join(path)
+  Pathname(__FILE__).join("../../repos").expand_path.join(path)
 end
 
 def bash_functions_file

--- a/spec/unit/bash_functions_spec.rb
+++ b/spec/unit/bash_functions_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "bash_functions.sh" do
 
   it "downloads ruby to BUILDPACK_DIR vendor directory" do
     Dir.mktmpdir do |dir|
-      dir = Pathname.new(dir)
+      dir = Pathname(dir)
 
       exec_with_bash_functions(<<~EOM, stack: "heroku-18")
         BUILDPACK_DIR="#{dir}"
@@ -90,7 +90,7 @@ RSpec.describe "bash_functions.sh" do
 
   it "bootstraps ruby using toml file" do
     Dir.mktmpdir do |dir|
-      dir = Pathname.new(dir)
+      dir = Pathname(dir)
 
       FileUtils.cp(
         root_dir.join("buildpack.toml"), # From

--- a/spec/unit/bundle_install_spec.rb
+++ b/spec/unit/bundle_install_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "BundleInstall" do
   it "sets env vars and does not clear cache if nothing changed" do
     Hatchet::Runner.new("default_ruby").in_directory_fork do
       stringio = StringIO.new
-      app_dir = Pathname.new(Dir.pwd)
+      app_dir = Pathname(Dir.pwd)
       gems_dir = app_dir.join(".heroku/ruby/gems").tap(&:mkpath)
 
       # The Bundler.with_original_env will Reset bundler's env vars since we're running in a `bundle exec` context for tests already
@@ -51,7 +51,7 @@ RSpec.describe "BundleInstall" do
   it "handles BUNDLE_WITHOUT with a space" do
     Hatchet::Runner.new("default_ruby").in_directory_fork do
       stringio = StringIO.new
-      app_dir = Pathname.new(Dir.pwd)
+      app_dir = Pathname(Dir.pwd)
       gems_dir = app_dir.join(".heroku/ruby/gems").tap(&:mkpath)
 
       Bundler.with_original_env do

--- a/spec/unit/bundler_lockfile_parser_spec.rb
+++ b/spec/unit/bundler_lockfile_parser_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "lockfile parser" do
   it "can read dependencies" do
     isolate_in_fork do
       Dir.mktmpdir do |dir|
-        dir = Pathname.new(dir)
+        dir = Pathname(dir)
         lockfile = dir.join("Gemfile.lock")
         lockfile.write <<~EOM
           PATH

--- a/spec/unit/bundler_strip_bundled_with_spec.rb
+++ b/spec/unit/bundler_strip_bundled_with_spec.rb
@@ -3,7 +3,7 @@ require_relative "../spec_helper.rb"
 RSpec.describe "BundlerStripBundledWith" do
   it "removes bundled with contents from disk" do
     Tempfile.create("Gemfile.lock") do |lockfile|
-      lockfile = Pathname.new(lockfile)
+      lockfile = Pathname(lockfile)
       lockfile.write <<~EOM
         before
         BUNDLED WITH

--- a/spec/unit/cache_copy_spec.rb
+++ b/spec/unit/cache_copy_spec.rb
@@ -3,7 +3,7 @@ require_relative "../spec_helper.rb"
 RSpec.describe "cache copy" do
   it "" do
     Dir.mktmpdir do |dir|
-      dir = Pathname.new(dir)
+      dir = Pathname(dir)
       dest_dir = dir.join("foo").tap(&:mkpath)
       cache_dir = dir.join("cache").tap(&:mkpath)
 

--- a/spec/unit/env_proxy_spec.rb
+++ b/spec/unit/env_proxy_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "env proxy" do
     expect(File.read(profile_d.path).strip).to include(%Q{export #{env_var_2.key}="$HOME/river:$#{env_var_2.key}"})
 
     Dir.mktmpdir do |dir|
-      layers_dir = Pathname.new(dir)
+      layers_dir = Pathname(dir)
       HerokuBuildpackRuby::EnvProxy.write_layers(
         layers_dir: layers_dir,
       )
@@ -116,7 +116,7 @@ RSpec.describe "env proxy" do
 
     # Can write to layers for CNB interface
     Dir.mktmpdir do |dir|
-      layers_dir = Pathname.new(dir)
+      layers_dir = Pathname(dir)
 
       env_var.write_layer(layers_dir: layers_dir)
 
@@ -153,7 +153,7 @@ RSpec.describe "env proxy" do
 
     # Can write to layers for CNB interface
     Dir.mktmpdir do |dir|
-      layers_dir = Pathname.new(dir)
+      layers_dir = Pathname(dir)
 
       env_var.write_layer(layers_dir: layers_dir)
 
@@ -189,7 +189,7 @@ RSpec.describe "env proxy" do
 
     # Can write to layers for CNB interface
     Dir.mktmpdir do |dir|
-      layers_dir = Pathname.new(dir)
+      layers_dir = Pathname(dir)
 
       env_var.write_layer(layers_dir: layers_dir)
 

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "metadata" do
   describe "top level interface" do
     it "works" do
       Dir.mktmpdir do |dir|
-        dir = Pathname.new(dir)
+        dir = Pathname(dir)
         metadata = HerokuBuildpackRuby::Metadata.new(dir: dir, type: HerokuBuildpackRuby::Metadata::CNB)
         expect(metadata.layer(:ruby).class).to eq(HerokuBuildpackRuby::Metadata::CNB)
 
@@ -23,7 +23,7 @@ RSpec.describe "metadata" do
   describe "in memory Engine" do
     it "works" do
       Dir.mktmpdir do |dir|
-        dir = Pathname.new(dir)
+        dir = Pathname(dir)
         engine = HerokuBuildpackRuby::Metadata::InMemory.new(dir: dir, name: :ruby)
         expect(engine.get(:foo)).to be_nil
         engine.set(foo: "bar")
@@ -48,7 +48,7 @@ RSpec.describe "metadata" do
   describe "CNB Engine" do
     it "works" do
       Dir.mktmpdir do |dir|
-        dir = Pathname.new(dir)
+        dir = Pathname(dir)
         engine = HerokuBuildpackRuby::Metadata::CNB.new(dir: dir, name: :ruby)
         expect(engine.get(:foo)).to be_nil
         engine.set(foo: "bar")
@@ -81,7 +81,7 @@ RSpec.describe "metadata" do
   describe "V2 Engine" do
     it "works" do
       Dir.mktmpdir do |dir|
-        dir = Pathname.new(dir)
+        dir = Pathname(dir)
         engine = HerokuBuildpackRuby::Metadata::V2.new(dir: dir, name: :ruby)
         expect(engine.get(:foo)).to be_nil
         engine.set(foo: "bar")

--- a/spec/unit/prepare_app_bundler_and_ruby_spec.rb
+++ b/spec/unit/prepare_app_bundler_and_ruby_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe "PrepareAppBundlerAndRuby" do
       Dir.mktmpdir do |app_dir|
         Dir.mktmpdir do |vendor_dir|
           isolate_in_fork do
-            app_dir = Pathname.new(app_dir)
-            vendor_dir = Pathname.new(vendor_dir)
+            app_dir = Pathname(app_dir)
+            vendor_dir = Pathname(vendor_dir)
 
-            gemfile = Pathname.new(app_dir).join("Gemfile")
+            gemfile = Pathname(app_dir).join("Gemfile")
 
             gemfile.write("")
 
-            lockfile = Pathname.new(app_dir).join("Gemfile.lock")
+            lockfile = Pathname(app_dir).join("Gemfile.lock")
             lockfile.write <<~EOM
               RUBY VERSION
                  ruby 2.7.2p146
@@ -47,7 +47,7 @@ RSpec.describe "PrepareAppBundlerAndRuby" do
   describe "ruby" do
     it "detects version" do
       Dir.mktmpdir do |dir|
-        lockfile = Pathname.new(dir).join("Gemfile.lock")
+        lockfile = Pathname(dir).join("Gemfile.lock")
         lockfile.write <<~EOM
           RUBY VERSION
              ruby 2.6.23p146
@@ -68,7 +68,7 @@ RSpec.describe "PrepareAppBundlerAndRuby" do
   describe "bundler" do
     it "detects major bundler version" do
       Dir.mktmpdir do |dir|
-        lockfile = Pathname.new(dir).join("Gemfile.lock")
+        lockfile = Pathname(dir).join("Gemfile.lock")
         lockfile.write <<~EOM
           BUNDLED WITH
              2.1.4


### PR DESCRIPTION
Calling Pathname.new creates a new pathname each time while calling `Pathname()` will only allocate it it's not already a pathname.

```
require 'benchmark/ips'

require 'pathname'

p = Pathname.new(".")
Benchmark.ips do |x|
  x.report("Pathname.new") { Pathname.new(p) }
  x.report("Pathname()  ") { Pathname(p) }
  x.compare!
end


# Warming up --------------------------------------
#         Pathname.new   198.032k i/100ms
#         Pathname()       1.546M i/100ms
# Calculating -------------------------------------
#         Pathname.new      1.952M (± 2.4%) i/s -      9.902M in   5.076761s
#         Pathname()       15.322M (± 2.5%) i/s -     77.314M in   5.049261s

# Comparison:
#         Pathname()  : 15321873.5 i/s
#         Pathname.new:  1951557.0 i/s - 7.85x  (± 0.00) slower
```

The resulting code is nearly ~7-8x faster. While it's likely not going to be a bottleneck anytime soon, let's not be in a habit of writing slow code when it's just as easy and clean to use faster code.