### PR TITLE
[changelog skip] Fix exporting path

### DIFF
--- a/lib/heroku_buildpack_ruby/env_proxy/base.rb
+++ b/lib/heroku_buildpack_ruby/env_proxy/base.rb
@@ -123,13 +123,8 @@ module HerokuBuildpackRuby
 
         build_dir = layer.join("env.build").tap(&:mkpath)
         value = Array(v).join(":")
-        build_dir.join(layer_key).open("w+") do |f|
-          f.write(value)
-        end
-
-        launch_dir.join(layer_key).open("w+") do |f|
-          f.write(value)
-        end
+        build_dir.join(layer_key).write(value)
+        launch_dir.join(layer_key).write(value)
       end
     end
 
@@ -162,11 +157,11 @@ module HerokuBuildpackRuby
       export_path = Pathname(export_path)
 
       profile_d_path.open("a") do |f|
-        f.write(to_export(replace: app_dir, with: "$HOME"))
+        f.puts(to_export(replace: app_dir, with: "$HOME"))
       end
 
       export_path.open("a") do |f|
-        f.write(to_export)
+        f.puts(to_export)
       end
     end
 

--- a/spec/unit/env_proxy_spec.rb
+++ b/spec/unit/env_proxy_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "env proxy" do
     )
 
     expect(
-      File.read(profile_d) # => '
+      File.read(profile_d).strip
     ).to eq(%Q{export #{env_var.key}="$HOME/rofl:$HOME/lol:haha:$#{env_var.key}"})
   ensure
     HerokuBuildpackRuby::EnvProxy.delete(env_var)
@@ -57,11 +57,11 @@ RSpec.describe "env proxy" do
       app_dir: "/app"
     )
 
-    expect(File.read(export.path).strip).to include(%Q{export #{env_var_1.key}="/app/cinco"})
-    expect(File.read(export.path).strip).to include(%Q{export #{env_var_2.key}="/app/river:$#{env_var_2.key}"})
+    expect(File.read(export.path)).to include(%Q{export #{env_var_1.key}="/app/cinco"\n})
+    expect(File.read(export.path)).to include(%Q{export #{env_var_2.key}="/app/river:$#{env_var_2.key}"\n})
 
-    expect(File.read(profile_d.path).strip).to include(%Q{export #{env_var_1.key}="$HOME/cinco"})
-    expect(File.read(profile_d.path).strip).to include(%Q{export #{env_var_2.key}="$HOME/river:$#{env_var_2.key}"})
+    expect(File.read(profile_d.path)).to include(%Q{export #{env_var_1.key}="$HOME/cinco"\n})
+    expect(File.read(profile_d.path)).to include(%Q{export #{env_var_2.key}="$HOME/river:$#{env_var_2.key}"\n})
 
     Dir.mktmpdir do |dir|
       layers_dir = Pathname(dir)


### PR DESCRIPTION
Previously we were not ensuring that there was a newline after each exported env var:

```
$ heroku run /bin/bash -a hatchet-t-1972d0f4da
Running /bin/bash on ⬢ hatchet-t-1972d0f4da... up, 
~ $ /bin/cat .profile.d/ruby.sh
export PATH="$HOME/.heroku/ruby/bundler/bin:$HOME/.heroku/ruby/ruby/bin:$PATH"export GEM_PATH="$HOME/.heroku/ruby/gems:$HOME/.heroku/ruby/gems:$HOME/.heroku/ruby/bundler:$GEM_PATH"export BUNDLE_GEMFILE="$HOME/Gemfile"export BUNDLE_BIN="$HOME/.heroku/ruby/gems/bin"export BUNDLE_PATH="$HOME/.heroku/ruby/gems"export BUNDLE_WITHOUT="${BUNDLE_WITHOUT:-development:test}"export BUNDLE_DEPLOYMENT="1"export BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SOURCE="1
```

This patch fixes that behavior and tests for it.