### PR TITLE
[changelog skip] Ensure that Nokogiri compiles against system

### DIFF
--- a/lib/heroku_buildpack_ruby/bundle_install.rb
+++ b/lib/heroku_buildpack_ruby/bundle_install.rb
@@ -8,6 +8,8 @@ module HerokuBuildpackRuby
     BUNDLE_DEPLOYMENT_ENV = EnvProxy.value("BUNDLE_DEPLOYMENT")
     BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE_ENV = EnvProxy.value("BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SOURCE")
 
+    NOKOGIRI_USE_SYSTEM_LIBRARIES_ENV = EnvProxy.value("NOKOGIRI_USE_SYSTEM_LIBRARIES")
+
     private; attr_reader :bundle_output, :bundle_without_default, :bundle_install_gems_dir, :user_comms, :bundle_gems_binsub_dir; public
 
     def initialize(app_dir: , bundle_without_default: , bundle_install_gems_dir:, user_comms: , metadata: Metadata::Null.new)
@@ -21,7 +23,7 @@ module HerokuBuildpackRuby
     end
 
     def call
-      prepare_env
+      bundle_config
       bundle_install
       bundle_clean
     end
@@ -46,7 +48,11 @@ module HerokuBuildpackRuby
       user_comms.puts "Bundle completed (#{"%.2f" % time }s)"
     end
 
-    private def prepare_env
+    private def bundle_config
+      NOKOGIRI_USE_SYSTEM_LIBRARIES_ENV.set(
+        gems: true
+      )
+
       GEM_PATH_ENV.prepend(
         gems: bundle_install_gems_dir,
         bundler: bundle_install_gems_dir

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe "This buildpack" do
         expect(app.output).to match("Installing rake")
         expect(app.run("ruby -v")).to match("2.6.6")
 
+        # Test that the system path isn't clobbered
+        expect(app.run("which bash").strip).to eq("/bin/bash")
+
         app.commit!
         app.push!
 
@@ -28,6 +31,44 @@ RSpec.describe "This buildpack" do
 
         expect(app.output).to include("installing node")
         expect(app.output).to include("installing yarn")
+      end
+    end
+  end
+
+  # https://github.com/heroku/heroku-buildpack-ruby/pull/124
+  it "nokogiri should use the system libxml2" do
+    Hatchet::Runner.new("default_ruby").tap do |app|
+      app.before_deploy do
+        dir = Pathname(Dir.pwd)
+        dir.join("Gemfile").write <<~EOM
+          source "https://rubygems.org"
+
+          gem "nokogiri", "1.6.0"
+        EOM
+
+        dir.join("Gemfile.lock").write <<~EOM
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              mini_portile (0.5.1)
+              nokogiri (1.6.0)
+                mini_portile (~> 0.5.0)
+
+          PLATFORMS
+            ruby
+
+          DEPENDENCIES
+            nokogiri (= 1.6.0)
+        EOM
+      end
+
+      app.deploy do
+        expect(app.output).to match("nokogiri")
+
+        expect(
+          app.run(%q{ruby -rnokogiri -e 'puts "Using system libxml2: #{Nokogiri::VersionInfo.new.libxml2_using_system?}"'})
+        ).to match("Using system libxml2: true")
+        expect($?.success?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Nokogiri is a HTML parser that is a native extension and needs to compile and link to libxml2.

Nokogiri ships with a version of vendor libxml2 and when you run `bundle install` with nokogiri it defaults to using the vendor version.

The stack image of Heroku provides libxml2. It's important that we tell nokogiri to use the stack image's version of libxml2 otherwise when libxml2 receives a security patch via the stack, nokogiri will not receive the patch.

To facilitate this we can set the env var NOKOGIRI_USE_SYSTEM_LIBRARIES=true. While this is tested in the existing Ruby buildpack https://github.com/heroku/heroku-buildpack-ruby/blob/38cb9c1e8e16fd09cdf2086387fe9a1882d920de/spec/hatchet/bugs_spec.rb#L4-L8 the test is not valid as it will not emit a warning even if it does not build with system ruby. This test is more explicit about the behavior we're desiring