### PR TITLE
[changelog skip] Fix lockfile parser with test

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,17 @@ Instead of "version_ruby" and "version_bundler" consider "ruby_version" and "rub
 
 Share behavior by sharing objects when possible. Relatedly: Strive for DRY concepts, not DRY source code.
 
-## Initialize values, call behavior
+### Initialize values, call behavior
 
 In general it's prefered to initialize all values when creating an object rather than passing values in later. We also want to decouple actions from initialization. The pattern here is to have actions respond when executintg `call` on the object. In general it allows us to be flexible with when we create our objets and when we use them.
+
+## External concepts
+
+These are external concepts that you may run into while working in this codebase. They're not always immediately self-explanatory, this section might help to understand their intended use cases.
+
+### Bundler.with_original_env do
+
+This invocation is frequently used in tests. It essentially tells bundler to set environment variables back to what they were before bundler was invoked. This is needed when we are wanting to simulate running a ruby command from the command line without bundler invoked yet. It's not always needed in every context, but if you see it, now you know why it's there and what the goal is.
 
 ### Ideas
 

--- a/lib/heroku_buildpack_ruby/bundler_lockfile_parser.rb
+++ b/lib/heroku_buildpack_ruby/bundler_lockfile_parser.rb
@@ -20,7 +20,9 @@ module HerokuBuildpackRuby
     # Loads the lockfile parser from Bundler source into memory so we can use it
     # to parse Gemfile.lock returns self
     def call
-      require_relative bundler_lib_path.join("bundler/lockfile_parser.rb")
+      $LOAD_PATH.prepend(bundler_lib_path.to_s)
+
+      require 'bundler'
       self
     end
 

--- a/spec/unit/bundler_lockfile_parser_spec.rb
+++ b/spec/unit/bundler_lockfile_parser_spec.rb
@@ -2,61 +2,80 @@ require_relative "../spec_helper.rb"
 
 RSpec.describe "lockfile parser" do
   it "can read dependencies" do
-    isolate_in_fork do
-      Dir.mktmpdir do |dir|
-        dir = Pathname(dir)
-        lockfile = dir.join("Gemfile.lock")
-        lockfile.write <<~EOM
-          PATH
-            remote: .
-            specs:
-              mini_histogram (0.3.1)
+    Dir.mktmpdir do |dir|
+      dir = Pathname(dir)
+      lockfile = dir.join("Gemfile.lock")
+      lockfile.write <<~EOM
+        PATH
+          remote: .
+          specs:
+            mini_histogram (0.3.1)
 
-          GEM
-            remote: https://rubygems.org/
-            specs:
-              benchmark-ips (2.7.2)
-              m (1.5.1)
-                method_source (>= 0.6.7)
-                rake (>= 0.9.2.2)
-              method_source (0.9.2)
-              minitest (5.14.0)
-              rake (12.3.3)
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            benchmark-ips (2.7.2)
+            m (1.5.1)
+              method_source (>= 0.6.7)
+              rake (>= 0.9.2.2)
+            method_source (0.9.2)
+            minitest (5.14.0)
+            rake (12.3.3)
 
-          PLATFORMS
-            ruby
+        PLATFORMS
+          ruby
 
-          DEPENDENCIES
-            benchmark-ips
-            m
-            mini_histogram!
-            minitest (~> 5.0)
-            rake (~> 12.0)
+        DEPENDENCIES
+          benchmark-ips
+          m
+          mini_histogram!
+          minitest (~> 5.0)
+          rake (~> 12.0)
 
-          BUNDLED WITH
-             2.1.4
-        EOM
+        BUNDLED WITH
+           2.1.4
+      EOM
 
-        bundler_install_dir = dir.join("bundler").tap(&:mkpath)
-        HerokuBuildpackRuby::BundlerDownload.new(
-          version: "2.1.4",
-          install_dir: bundler_install_dir
-        ).call
+      # We need bundler internal locations
+      #
+      # We could use the already installed bundler on disk,
+      # but `which bundler` points to the binstub and not to
+      # the install location which may be different, it's easier
+      # to just download a copy every time
+      bundler_install_dir = dir.join("bundler").tap(&:mkpath)
+      HerokuBuildpackRuby::BundlerDownload.new(
+        version: "2.1.4",
+        install_dir: bundler_install_dir
+      ).call
 
+      # We need to be able to make sure our code works
+      # when no bundler version is loaded, to simulate this
+      # we write a script to disk then execute it with a raw
+      # `ruby` command.
+      script = dir.join("script.rb")
+      script.write <<~EOM
+        $LOAD_PATH << "#{root_dir.join('lib')}"
 
-        Bundler.send(:remove_const, :LockfileParser)
+        raise "This constant should not be loaded yet Bundler::LockfileParser" if defined?(Bundler::LockfileParser)
 
-        expect(defined?(Bundler::LockfileParser)).to be_falsey
+        require 'heroku_buildpack_ruby'
 
         dependencies = HerokuBuildpackRuby::BundlerLockfileParser.new(
-          gemfile_lock_path: lockfile,
-          bundler_install_dir: bundler_install_dir,
+          gemfile_lock_path: "#{lockfile}",
+          bundler_install_dir: "#{bundler_install_dir}",
         ).call
 
-        expect(dependencies.bundler_lib_path.to_s).to eq(bundler_install_dir.join("gems/bundler-2.1.4/lib").to_s)
-        expect(dependencies.has_gem?("minitest")).to be_truthy
-        expect(dependencies.version("minitest")).to eq(Gem::Version.new("5.14.0"))
-        expect(dependencies.windows?).to be_falsey
+        puts "Has minitest: \#{dependencies.has_gem?("minitest")}"
+        puts "Minitest Version: \#{dependencies.version("minitest")}"
+        puts "Windows: \#{!!dependencies.windows?}"
+      EOM
+
+      Bundler.with_original_env do
+        out = HerokuBuildpackRuby::Bash.new("ruby #{script}").run!
+
+        expect(out).to include("Has minitest: true")
+        expect(out).to include("Minitest Version: 5.14.0")
+        expect(out).to include("Windows: false")
       end
     end
   end


### PR DESCRIPTION
The lock file parser has reference to other bundler defined constants such as Bundle::Source. While we could attempt to whack-a-mole each of these requires, that would be brittle. Instead we can require the entirety of bundler.

The existing test did not catch this because it is being called from within a bundler context already. To write a failing test that would have caught this issue, I needed a pristine ruby environment without bundler loaded. To get this I wrote the code to text against to a script file. Then I am manually executing that script via Bash.new("ruby script.rb"). And I'm wrapping that in a Bundler.with_original_env. This combination provides a similar/same environment as the Ruby buildpack (executing the code without bundler loaded yet).

This approach caused the old code to fail, and allows the new code to pass. It will hopefully be more robust then the previous lock file parser tests.