### PR TITLE
[changelog skip] Install node for apps with execjs

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,10 +6,15 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-BIN_DIR=$(cd $(dirname $0); pwd)
-BUILDPACK_DIR=$(dirname $BIN_DIR)
+BIN_DIR=$(cd $(dirname "$0"); pwd)
+BUILDPACK_DIR=$(dirname "$BIN_DIR")
 
 source "$BIN_DIR/support/bash_functions.sh"
+
+if needs_package_json "$BUILD_DIR"; then
+  echo "      Writing package.json"
+  echo "{}" > "$BUILD_DIR/package.json"
+fi
 
 if detect_needs_node "$BUILD_DIR"; then
   cat <<EOM

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 curl_retry_on_18() {
   local ec=18;
   local attempts=0;
@@ -176,19 +178,39 @@ which_node()
   which node
 }
 
-# Returns truthy if the project needs node installed
+# Returns truthy if the project needs node installed but does not
+# have a package.json for example if a Gem in the gemfile depends on node
+needs_package_json()
+{
+  local app_dir=$1
+  local truthy=0
+  local falsey=1
+
+  # If it already has it, don't over-write
+  if [ -f "$app_dir/package.json" ];then
+    return $falsey
+  fi
+
+  if grep -Fq "execjs" "$app_dir/Gemfile.lock";then
+    return $truthy
+  else
+    return $falsey
+  fi
+}
+
 detect_needs_node()
 {
+
+  local app_dir=$1
 
   local needs_node=0
   local skip_node_install=1
 
-  if [ $(which_node) ]; then
+  if which_node; then
     return $skip_node_install
   fi
 
-  local build_dir=$1
-  if [ -f "$build_dir/package.json" ];then
+  if [ -f "$app_dir/package.json" ];then
     return $needs_node
   else
     return $skip_node_install

--- a/hatchet.json
+++ b/hatchet.json
@@ -1,5 +1,6 @@
 {
   "ruby_apps": [
+    "heroku/ruby-getting-started",
     "sharpstone/default_ruby",
     "sharpstone/minimal_webpacker"
   ],

--- a/hatchet.lock
+++ b/hatchet.lock
@@ -7,3 +7,5 @@
   - 6e642963acec0ff64af51bd6fba8db3c4176ed6e
 - - "./repos/ruby_apps/minimal_webpacker"
   - be01668e40f059a29d0358f7a30c79fb58e51b63
+- - "./repos/ruby_apps/ruby-getting-started"
+  - main

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe "This buildpack" do
     end
   end
 
+  it "getting started guide" do
+    Hatchet::Runner.new("ruby-getting-started").deploy do |app|
+      # TODO: Remove asset fragment cache before runtime for reduced slug size
+      # expect(app.run("ls tmp/cache/assets")).to_not match("sprockets")
+    end
+  end
+
   it "bundler 1.x" do
     Hatchet::Runner.new("default_ruby").tap do |app|
       app.before_deploy do


### PR DESCRIPTION
The `execjs` gem allows Ruby code to execute javascript. It does this by searching for several possible implementations:

- The ruby racer (V8 distributed as a Ruby gem)
  - This gems is extremely heavy, takes a long time to compile, frequently fails compilation and is generally not commonly used.
- MinRacer (A paired down interface to V8 distrbuted as a Ruby gem)
  - From the readme: Unlike therubyracer, mini_racer only implements a minimal bridge. This reduces the surface area making upgrading v8 much simpler and exhaustive testing simpler.
- System installation of `node`

Prior to the introduction of `mini_racer` the most common and popular development strategy was to depend on a system version of `node`. This PR implements existing behavior in the old buildpack where we install node if `execjs` is present in the gemfile.lock https://github.com/heroku/heroku-buildpack-ruby/blob/38cb9c1e8e16fd09cdf2086387fe9a1882d920de/lib/language_pack/ruby.rb#L1153-L1154. While this might sound like an edge case. Our existing "getting started ruby" example app needs this behavior https://github.com/heroku/ruby-getting-started

Unlike the old Ruby buildpack we do not manually manage and install a node binary, instead we rely on the Node buildpack to install and manage node so that user expectations are more aligned.

## Implementation details

The Node.js buildpack requires a `package.json` copy at the root of the buildpack for detection. In our case the developer may not have added one, but we still need to use the `heroku/nodejs` buildpack to manage our node for us. To accomplish this the Ruby buildpack detects this scenario and writes out a minimal `package.json` so that the nodejs buildpack will not fail detection.

## CNB Concerns

This same strategy does not work for CNB because the detect phase runs in parallel so even if the Ruby buildpack writes a `package.json` to disk as part of it's detect phase, it's too late and the nodejs buildpack's detect has already fired. While this strategy seems to work well enough for the V2 interface, we need to figure out how to support this behavior with the CNB interface.