### PR TITLE
[changelog skip] Support User Env config vars

### DIFF
--- a/lib/heroku_buildpack_ruby.rb
+++ b/lib/heroku_buildpack_ruby.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "heroku_buildpack_ruby/user_env_from_dir.rb"
+
 require_relative "heroku_buildpack_ruby/prepare_app_bundler_and_ruby.rb"
 require_relative "heroku_buildpack_ruby/bundler_lockfile_parser.rb"
 require_relative "heroku_buildpack_ruby/bundle_install.rb"
@@ -29,6 +31,7 @@ module HerokuBuildpackRuby
 
   def self.compile_legacy(build_dir: , cache_dir:, env_dir: , buildpack_ruby_path:)
     app_dir = Pathname(build_dir)
+    UserEnv.parse(env_dir)
 
     Dir.chdir(app_dir) do
       export = BUILDPACK_DIR.join("export")
@@ -66,7 +69,6 @@ module HerokuBuildpackRuby
         ).call
       end
 
-
       lockfile = HerokuBuildpackRuby::BundlerLockfileParser.new(
         gemfile_lock_path: gemfile_lock_path,
         bundler_install_dir: bundler_install_dir,
@@ -99,6 +101,8 @@ module HerokuBuildpackRuby
   end
 
   def self.build_cnb(layers_dir: , platform_dir: , env_dir: , plan: , app_dir: , buildpack_ruby_path:)
+    UserEnv.parse(env_dir)
+
     Dir.chdir(app_dir) do
       app_dir = Pathname(app_dir)
       layers_dir = Pathname(layers_dir)

--- a/lib/heroku_buildpack_ruby/env_proxy.rb
+++ b/lib/heroku_buildpack_ruby/env_proxy.rb
@@ -133,8 +133,8 @@ module HerokuBuildpackRuby
     #   puts ENV["LOL"] #=> "haha"
     #
     #   > Note: The value didn't change since it was already set
-    def self.default(key)
-      value = EnvProxy::Default.new(key)
+    def self.default(key, user_env: UserEnv)
+      value = EnvProxy::Default.new(key, user_env: user_env)
       @env_array << value
       value
     end

--- a/lib/heroku_buildpack_ruby/env_proxy/base.rb
+++ b/lib/heroku_buildpack_ruby/env_proxy/base.rb
@@ -44,8 +44,9 @@ module HerokuBuildpackRuby
     # - EnvPxoxy.value("FOO")
     # - EnvPxoxy.path("FOO_PATH")
     #
-    def initialize(key)
+    def initialize(key, user_env: UserEnv)
       @key = key
+      @user_env = user_env
 
       @layer_env_hash = {}
     end
@@ -60,7 +61,7 @@ module HerokuBuildpackRuby
     #
     #   puts LOL_PATH_ENV.to_env # => 'LOL_PATH="/app/lol" '
     def to_env
-      %Q{#{key}="#{ENV[key]}" }
+      %Q{#{key}="#{value}" }
     end
 
     # Returns the currently set env var

--- a/lib/heroku_buildpack_ruby/env_proxy/default.rb
+++ b/lib/heroku_buildpack_ruby/env_proxy/default.rb
@@ -55,7 +55,7 @@ module HerokuBuildpackRuby
         @layer_env_hash[k] = value
       end
 
-      ENV[@key] ||= value
+      ENV[key] ||= @user_env[key] || value
 
       self
     end

--- a/lib/heroku_buildpack_ruby/ruby_detect_version.rb
+++ b/lib/heroku_buildpack_ruby/ruby_detect_version.rb
@@ -75,7 +75,8 @@ module HerokuBuildpackRuby
     def bundler_output_from_shell!
       # Run `bundle platform --ruby` but use the bootstrapped version of ruby for the buildpack
       # To do this we directly call the bootstrapped binary path then directly pass it the bootstrapped ruby
-      output = Bash.new(%Q{BUNDLE_GEMFILE="#{gemfile_path}" #{buildpack_ruby_path} #{bundler_path} platform --ruby}).run!
+      command = %Q{BUNDLE_GEMFILE="#{gemfile_path}" #{buildpack_ruby_path} #{bundler_path} platform --ruby}
+      output = Bash.new(command, user_env: false).run!
       output = output.strip.lines.last
 
       if output.match(/No ruby version specified/)

--- a/lib/heroku_buildpack_ruby/user_env_from_dir.rb
+++ b/lib/heroku_buildpack_ruby/user_env_from_dir.rb
@@ -1,0 +1,60 @@
+require "shellwords"
+
+module HerokuBuildpackRuby
+  # This parses and emulates an ENV object for user
+  # supplied values
+  #
+  # Example:
+  #
+  #   dir.join("HELLO").write("there")
+  #
+  #   env = UserEnvFromDir.new.parse(dir)
+  #   puts env["HELLO"] # => "there
+  class UserEnvFromDir
+    def initialize(deny_list: [])
+      @hash = {}
+      @deny_list = deny_list
+      @deny_list.concat %W{PATH GEM_PATH GEM_HOME GIT_DIR}
+      @deny_list.concat %W{JRUBY_OPTS JAVA_OPTS JAVA_TOOL_OPTIONS}
+    end
+
+    def parse(dir)
+      dir = Pathname(dir)
+      dir.entries.sort.each do |entry|
+        path = dir.join(entry)
+        next if path.directory?
+
+        key = path.basename.to_s
+        @hash[key] = path.read unless @deny_list.include?(key)
+      end
+
+      self
+    end
+
+    def empty?
+      @hash.empty?
+    end
+
+    def any?
+      !empty?
+    end
+
+    def to_shell
+      @hash.map {|key, value| %Q{#{key.shellescape}="#{value.shellescape}"} }.join(" ")
+    end
+
+    def [](key)
+      @hash[key]
+    end
+
+    def key?(key)
+      @hash.key?(key)
+    end
+
+    def clear
+      @hash.clear
+    end
+  end
+
+  UserEnv = UserEnvFromDir.new
+end

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -3,6 +3,17 @@
 require_relative "../spec_helper.rb"
 
 RSpec.describe "This buildpack" do
+  it "user env compile" do
+    Hatchet::Runner.new("default_ruby", config: {"BUNDLE_WITHOUT": "periwinkle"}).tap do |app|
+      app.before_deploy do
+      end
+      app.deploy do
+        expect(app.output).to include(%Q{BUNDLE_WITHOUT="periwinkle"})
+        expect(app.output).to match("Installing bundler 1.")
+      end
+    end
+  end
+
   it "bundler 1.x" do
     Hatchet::Runner.new("default_ruby").tap do |app|
       app.before_deploy do

--- a/spec/unit/bash_functions_spec.rb
+++ b/spec/unit/bash_functions_spec.rb
@@ -2,9 +2,7 @@
 
 require_relative "../spec_helper.rb"
 
-# Log Dir.chdir
-# Log ENV setting and getting
-#
+
 RSpec.describe "bash_functions.sh" do
   def exec_with_bash_functions(code, stack: "heroku-18")
     contents = <<~EOM

--- a/spec/unit/bash_spec.rb
+++ b/spec/unit/bash_spec.rb
@@ -1,0 +1,48 @@
+require_relative "../spec_helper.rb"
+
+module HerokuBuildpackRuby
+  RSpec.describe "bash.rb" do
+    it "uses user env" do
+      user_env = Object.new
+      def user_env.to_shell; %Q{WHY="theluckystiff"}; end
+      def user_env.empty?; false; end
+
+      bash = Bash.new('echo "Hello $WHY"', user_env: user_env)
+      expect(bash.run.strip).to eq("Hello theluckystiff")
+
+      bash = Bash.new('echo "Hello $WHY"', user_env: false)
+      expect(bash.run.strip).to eq("Hello")
+    end
+
+    describe "on error" do
+      it "can error on run!" do
+        bash = Bash.new("echo 'nope'; exit1")
+        expect {
+          bash.run!
+        }.to raise_error(/Bash command failed/)
+      end
+
+      it "returns the original command" do
+        bash = Bash.new("echo 'nope'; exit 1")
+        expect {
+          bash.run!
+        }.to raise_error(/echo 'nope'; exit 1/)
+      end
+
+      it "redacts env vars" do
+        user_env = Object.new
+        def user_env.to_shell; %Q{WHY="theluckystiff"}; end
+        def user_env.empty?; false; end
+
+        bash = Bash.new("echo 'nope'; exit 1", user_env: user_env)
+        expect {
+          bash.run!
+        }.to raise_error(/<REDACTED> bash -c echo/)
+
+        expect(bash.command_without_env).to(
+          eq("/usr/bin/env <REDACTED> bash -c echo\\ \\'nope\\'\\;\\ exit\\ 1 2>&1")
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/user_env_from_dir_spec.rb
+++ b/spec/unit/user_env_from_dir_spec.rb
@@ -1,0 +1,42 @@
+require_relative "../spec_helper.rb"
+
+module HerokuBuildpackRuby
+  RSpec.describe "UserEnvFromDir" do
+    it "handles empty contents" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+
+        env = UserEnvFromDir.new.parse(dir)
+
+        expect(env.key?("FOUR")).to be_falsey
+        expect(env["FOUR"]).to eq(nil)
+        expect(env.to_shell).to eq(%Q{})
+      end
+    end
+
+    it "reads from the env dir" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+        dir.join("FOUR").write("seasons")
+        dir.join("TOTAL").write("landscaping")
+
+        env = UserEnvFromDir.new.parse(dir)
+
+        expect(env.key?("FOUR")).to be_truthy
+        expect(env["FOUR"]).to eq("seasons")
+        expect(env.to_shell).to eq(%Q{FOUR="seasons" TOTAL="landscaping"})
+      end
+    end
+
+    it "has a deny list" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+        dir.join("PATH").write("lol")
+
+        env = UserEnvFromDir.new.parse(dir)
+
+        expect(env.key?("PATH")).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
Most other buildpacks import the user defined config values into the same process that is running the buildpack code. The Ruby buildpack gains additional control by not doing this and instead parsing and storing this information so it can be used later.

## UserEnvFromDir

This is a multi purpose class that encapsulates env parsing logic. It acts similar to the ENV hash.

Populating this object and creating it are decoupled. This allows us to create a global instance before loading the env directory, and then later populate it.

## UserEnv constant

The `UserEnv` constant is a global instance of `UserEnvFromDir`. All code can depend on it being present. It is being accessed by `Bash`, `EnvProxy::Default`, `EnvProxy::Base`, and `EnvProxy` as well as the top level HerokuBuildpackRuby methods

## EnvProxy::Default

This class is now aware of the UserEnv object. If a key is present in the UserEnv object it will prefer that value.

The big caveat here is that if someone is specifying a default env proxy object, they should be aware that it will mutate the buildpack's ENV. It's not ideal, but this prevents us from having multiple sources of truth in regards to the current value. Since this behavior is limited only to constants declared as EnvProxy.default, it limits the impact on the current process to a subset of values that the user is expected to be able to set anyway.

We could decouple this behavior in the future, but I think in the long run mutating ENV in this one sub case will cause fewer headaches.

## EnvProxy::Base

To support EnvProxy::Default behavior the base object now takes an optional `user_env:` kwarg and defaults to `UserEnv`.

## EnvProxy.default

To support building a EnvProxy::Default object, this method now accepts an optional `user_env` kwarg and defaults to `UserEnv`

## Bash.rb

The bash object is aware of the global `UserEnv` object and by default will run commands with the user's config values. By default bash commands will use the user's config vars, but this can be toggled off by passing in a falsey value:

```
Bash.rb("ls", user_env: false).run
```

## EnvProxy spec

To simplify tests, I've wrapped the specs in a top level module definition so that we don't have to use the fully qualified HerokuBuildapackRuby constant all over the place.

## Detect Ruby Version

The only place that we need to directly call the bootstrapped ruby version is to retrieve the `bundle platform --ruby` output. Since our version of Ruby is likely different that other versions of Ruby we will execute this without env vars. This allows us to not have to deny-list env vars such as RUBYOPT. I believe this is sufficient for our cases,