### PR TITLE
[changelog skip] Wrap all specs in a namespace

### DIFF
--- a/spec/cnb/buildpack_spec.rb
+++ b/spec/cnb/buildpack_spec.rb
@@ -76,63 +76,65 @@ class CnbRun
   end
 end
 
-RSpec.describe "Cloud Native Buildpack" do
-  it "locally runs default_ruby app" do
-    CnbRun.new(hatchet_path("ruby_apps/default_ruby"), buildpack_paths: [buildpack_path]).call do |app|
-      expect(app.output).to include("Installing rake")
+module HerokuBuildpackRuby
+  RSpec.describe "Cloud Native Buildpack" do
+    it "locally runs default_ruby app" do
+      CnbRun.new(hatchet_path("ruby_apps/default_ruby"), buildpack_paths: [buildpack_path]).call do |app|
+        expect(app.output).to include("Installing rake")
 
-      app.run_multi!("ruby -v") do |out|
-        expect(out).to match(HerokuBuildpackRuby::RubyDetectVersion::DEFAULT)
-      end
+        app.run_multi!("ruby -v") do |out|
+          expect(out).to match(RubyDetectVersion::DEFAULT)
+        end
 
-      app.run_multi!("bundle list") do |out|
-        expect(out).to match("rack")
-      end
+        app.run_multi!("bundle list") do |out|
+          expect(out).to match("rack")
+        end
 
-      app.run_multi!("gem list") do |out|
-        expect(out).to match("rack")
-      end
+        app.run_multi!("gem list") do |out|
+          expect(out).to match("rack")
+        end
 
-      app.run_multi!(%Q{ruby -e "require 'rack'; puts 'done'"}) do |out|
-        expect(out).to match("done")
-      end
+        app.run_multi!(%Q{ruby -e "require 'rack'; puts 'done'"}) do |out|
+          expect(out).to match("done")
+        end
 
-      app.build!
+        app.build!
 
-      expect(app.output).to include("Using rake")
-    end
-  end
-
-  it "installs node and yarn and calls assets:precompile" do
-    CnbRun.new(hatchet_path("ruby_apps/minimal_webpacker"), buildpack_paths: ["heroku/nodejs", buildpack_path]).call do |app|
-      # This output comes from the heroku/nodejs buildpack
-      expect(app.output).to include("Installing rake")
-      expect(app.output).to include("Installing yarn")
-
-      # This output comes from the contents of the Rakefile
-      # https://github.com/sharpstone/minimal_webpacker/blob/master/Rakefile
-      expect(app.output).to include("THE TASK ASSETS:PRECOMPILE WAS CALLED")
-      expect(app.output).to include("THE TASK ASSETS:CLEAN WAS CALLED")
-
-      app.run_multi!("which node") do |out, status|
-        expect(out.strip).to_not be_empty
-        expect(status.success?).to be_truthy
-      end
-
-      app.run_multi!("which yarn") do |out, status|
-        expect(out.strip).to_not be_empty
-        expect(status.success?).to be_truthy
+        expect(app.output).to include("Using rake")
       end
     end
-  end
 
-  it "Respects user config vars" do
-    CnbRun.new(
-      hatchet_path("ruby_apps/default_ruby"),
-      buildpack_paths: [buildpack_path],
-      config: {"BUNDLE_WITHOUT": "periwinkle"}
-    ).call do |app|
-      expect(app.output).to include(%Q{BUNDLE_WITHOUT="periwinkle"})
+    it "installs node and yarn and calls assets:precompile" do
+      CnbRun.new(hatchet_path("ruby_apps/minimal_webpacker"), buildpack_paths: ["heroku/nodejs", buildpack_path]).call do |app|
+        # This output comes from the heroku/nodejs buildpack
+        expect(app.output).to include("Installing rake")
+        expect(app.output).to include("Installing yarn")
+
+        # This output comes from the contents of the Rakefile
+        # https://github.com/sharpstone/minimal_webpacker/blob/master/Rakefile
+        expect(app.output).to include("THE TASK ASSETS:PRECOMPILE WAS CALLED")
+        expect(app.output).to include("THE TASK ASSETS:CLEAN WAS CALLED")
+
+        app.run_multi!("which node") do |out, status|
+          expect(out.strip).to_not be_empty
+          expect(status.success?).to be_truthy
+        end
+
+        app.run_multi!("which yarn") do |out, status|
+          expect(out.strip).to_not be_empty
+          expect(status.success?).to be_truthy
+        end
+      end
+    end
+
+    it "Respects user config vars" do
+      CnbRun.new(
+        hatchet_path("ruby_apps/default_ruby"),
+        buildpack_paths: [buildpack_path],
+        config: {"BUNDLE_WITHOUT": "periwinkle"}
+      ).call do |app|
+        expect(app.output).to include(%Q{BUNDLE_WITHOUT="periwinkle"})
+      end
     end
   end
 end

--- a/spec/docker/bash_functions_spec.rb
+++ b/spec/docker/bash_functions_spec.rb
@@ -2,45 +2,47 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "bash_functions.sh that need docker" do
-  it "compiles node apps" do
-    Hatchet::Runner.new("minimal_webpacker").in_directory do
-      contents = <<~EOM
-        #! /usr/bin/env bash
-        set -eu
-        export STACK="heroku-18"
+module HerokuBuildpackRuby
+  RSpec.describe "bash_functions.sh that need docker" do
+    it "compiles node apps" do
+      Hatchet::Runner.new("minimal_webpacker").in_directory do
+        contents = <<~EOM
+          #! /usr/bin/env bash
+          set -eu
+          export STACK="heroku-18"
 
-        #{bash_functions_file.read}
+          #{bash_functions_file.read}
 
 
-        build_dir="/tmp/build_dir"
-        cache_dir="/tmp/cache_dir"
-        env_dir="/tmp/env_dir"
+          build_dir="/tmp/build_dir"
+          cache_dir="/tmp/cache_dir"
+          env_dir="/tmp/env_dir"
 
-        mkdir -p "$cache_dir"
-        mkdir -p "$env_dir"
-        mkdir -p "$build_dir"
-        cp -r /myapp/* "$build_dir"
+          mkdir -p "$cache_dir"
+          mkdir -p "$env_dir"
+          mkdir -p "$build_dir"
+          cp -r /myapp/* "$build_dir"
 
-        compile_buildpack_v2 "$build_dir" "$cache_dir" "$env_dir" "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/nodejs.tgz" "heroku/nodejs"
+          compile_buildpack_v2 "$build_dir" "$cache_dir" "$env_dir" "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/nodejs.tgz" "heroku/nodejs"
 
-        echo "which node $(which node)"
-        echo "which yarn $(which yarn)"
-      EOM
+          echo "which node $(which node)"
+          echo "which yarn $(which yarn)"
+        EOM
 
-      script = Pathname(".").join("script.sh")
-      script.write(contents)
-      FileUtils.chmod("+x", script)
+        script = Pathname(".").join("script.sh")
+        script.write(contents)
+        FileUtils.chmod("+x", script)
 
-      output = `docker run -v "$PWD:/myapp" -it --rm heroku/heroku:18-build /myapp/script.sh 2>&1`
-      expect(output).to include("Build succeeded")
-      expect(output).to include("installing node")
-      expect(output).to include("installing yarn")
+        output = `docker run -v "$PWD:/myapp" -it --rm heroku/heroku:18-build /myapp/script.sh 2>&1`
+        expect(output).to include("Build succeeded")
+        expect(output).to include("installing node")
+        expect(output).to include("installing yarn")
 
-      expect(output).to include("which node /tmp/build_dir/.heroku/node/bin/node")
-      expect(output).to include("which yarn /tmp/build_dir/.heroku/yarn/bin/yarn")
+        expect(output).to include("which node /tmp/build_dir/.heroku/node/bin/node")
+        expect(output).to include("which yarn /tmp/build_dir/.heroku/yarn/bin/yarn")
 
-      expect($?.success?).to be_truthy
+        expect($?.success?).to be_truthy
+      end
     end
   end
 end

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -2,160 +2,162 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "This buildpack" do
-  it "user env compile" do
-    Hatchet::Runner.new("default_ruby", config: {"BUNDLE_WITHOUT": "periwinkle"}).tap do |app|
-      app.before_deploy do
-      end
-      app.deploy do
-        expect(app.output).to include(%Q{BUNDLE_WITHOUT="periwinkle"})
-        expect(app.output).to match("Installing bundler 1.")
-      end
-    end
-  end
-
-  it "getting started guide" do
-    Hatchet::Runner.new("ruby-getting-started").deploy do |app|
-      # TODO: Remove asset fragment cache before runtime for reduced slug size
-      # expect(app.run("ls tmp/cache/assets")).to_not match("sprockets")
-    end
-  end
-
-  it "bundler 1.x" do
-    Hatchet::Runner.new("default_ruby").tap do |app|
-      app.before_deploy do
-        Pathname(Dir.pwd)
-          .join("Gemfile.lock")
-          .write("BUNDLED WITH\n   1.1.0", mode: "a")
-      end
-      app.deploy do
-        # Test Bundler 1.x
-        expect(app.output).to match("Installing bundler 1.")
-      end
-    end
-  end
-
-  it "has its own tests" do
-    skip("Must set HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
-
-    Hatchet::Runner.new("default_ruby", run_multi: true).tap do |app|
-      app.before_deploy do
-        # TODO default process types
-        Pathname(Dir.pwd).join("Procfile").write <<~EOM
-          web: # No-op, needed so we can scale up for run_multi
-        EOM
-        Pathname(Dir.pwd)
-          .join("Gemfile.lock")
-          .write("BUNDLED WITH\n   2.1.4", mode: "a")
-      end
-      app.deploy do
-        # Test bundler 2.x
-        expect(app.output).to match("Installing bundler 2.")
-
-        # Test deploy succeeded
-        expect(app.output).to match("deployed to Heroku")
-
-        # Test dependencies installed
-        expect(app.output).to match("Installing rake")
-
-        # Test default ruby is installed
-        app.run_multi("ruby -v") do |out, status|
-          expect(out).to match(HerokuBuildpackRuby::RubyDetectVersion::DEFAULT)
-          expect(status.success?).to be_truthy
+module HerokuBuildpackRuby
+  RSpec.describe "This buildpack" do
+    it "user env compile" do
+      Hatchet::Runner.new("default_ruby", config: {"BUNDLE_WITHOUT": "periwinkle"}).tap do |app|
+        app.before_deploy do
         end
-
-        # Test that the system path isn't clobbered
-        app.run_multi("which bash") do |out, status|
-          expect(out.strip).to eq("/bin/bash")
-          expect(status.success?).to be_truthy
-        end
-
-        # Verify gem installation location does not change
-        # and binstubs are on the path
-        app.run_multi("which -a rake") do |out, status|
-          # Gem rake version
-          expect(out).to include("/app/.heroku/ruby/gems/bin/rake")
-          expect(status.success?).to be_truthy
-        end
-
-        # Test deploys twice without error
-        app.commit!
-        app.push!
-
-        # Test uses cache after re-deploy
-        expect(app.output).to match("Using rake")
-      end
-    end
-  end
-
-  it "installs node and yarn and calls assets:precompile" do
-    skip("Must set HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
-
-    Hatchet::Runner.new("minimal_webpacker", run_multi: true).tap do |app|
-      app.before_deploy do
-        Pathname(Dir.pwd).join("Procfile").write <<~EOM
-          web: # No-op, needed so we can scale up for run_multi
-        EOM
-      end
-      app.deploy do
-        # This output comes from the heroku/nodejs buildpack
-        expect(app.output).to include("installing yarn")
-
-        # This output comes from the Ruby buildpack
-        expect(app.output).to include("Installing rake")
-
-        # This output comes from the contents of the Rakefile
-        # https://github.com/sharpstone/minimal_webpacker/blob/master/Rakefile
-        expect(app.output).to include("THE TASK ASSETS:PRECOMPILE WAS CALLED")
-        expect(app.output).to include("THE TASK ASSETS:CLEAN WAS CALLED")
-
-        app.run_multi("which node") do |out, status|
-          expect(out.strip).to_not be_empty
-          expect(status.success?).to be_truthy
-        end
-
-        app.run_multi("which yarn") do |out, status|
-          expect(out.strip).to_not be_empty
-          expect(status.success?).to be_truthy
+        app.deploy do
+          expect(app.output).to include(%Q{BUNDLE_WITHOUT="periwinkle"})
+          expect(app.output).to match("Installing bundler 1.")
         end
       end
     end
-  end
 
-  # https://github.com/heroku/heroku-buildpack-ruby/pull/124
-  it "nokogiri should use the system libxml2" do
-    Hatchet::Runner.new("default_ruby").tap do |app|
-      app.before_deploy do
-        dir = Pathname(Dir.pwd)
-        dir.join("Gemfile").write <<~EOM
-          source "https://rubygems.org"
-
-          gem "nokogiri", "1.6.0"
-        EOM
-
-        dir.join("Gemfile.lock").write <<~EOM
-          GEM
-            remote: https://rubygems.org/
-            specs:
-              mini_portile (0.5.1)
-              nokogiri (1.6.0)
-                mini_portile (~> 0.5.0)
-
-          PLATFORMS
-            ruby
-
-          DEPENDENCIES
-            nokogiri (= 1.6.0)
-        EOM
+    it "getting started guide" do
+      Hatchet::Runner.new("ruby-getting-started").deploy do |app|
+        # TODO: Remove asset fragment cache before runtime for reduced slug size
+        # expect(app.run("ls tmp/cache/assets")).to_not match("sprockets")
       end
+    end
 
-      app.deploy do
-        expect(app.output).to match("nokogiri")
+    it "bundler 1.x" do
+      Hatchet::Runner.new("default_ruby").tap do |app|
+        app.before_deploy do
+          Pathname(Dir.pwd)
+            .join("Gemfile.lock")
+            .write("BUNDLED WITH\n   1.1.0", mode: "a")
+        end
+        app.deploy do
+          # Test Bundler 1.x
+          expect(app.output).to match("Installing bundler 1.")
+        end
+      end
+    end
 
-        expect(
-          app.run(%q{ruby -rnokogiri -e 'puts "Using system libxml2: #{Nokogiri::VersionInfo.new.libxml2_using_system?}"'})
-        ).to match("Using system libxml2: true")
-        expect($?.success?).to be_truthy
+    it "has its own tests" do
+      skip("Must set HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
+
+      Hatchet::Runner.new("default_ruby", run_multi: true).tap do |app|
+        app.before_deploy do
+          # TODO default process types
+          Pathname(Dir.pwd).join("Procfile").write <<~EOM
+            web: # No-op, needed so we can scale up for run_multi
+          EOM
+          Pathname(Dir.pwd)
+            .join("Gemfile.lock")
+            .write("BUNDLED WITH\n   2.1.4", mode: "a")
+        end
+        app.deploy do
+          # Test bundler 2.x
+          expect(app.output).to match("Installing bundler 2.")
+
+          # Test deploy succeeded
+          expect(app.output).to match("deployed to Heroku")
+
+          # Test dependencies installed
+          expect(app.output).to match("Installing rake")
+
+          # Test default ruby is installed
+          app.run_multi("ruby -v") do |out, status|
+            expect(out).to match(RubyDetectVersion::DEFAULT)
+            expect(status.success?).to be_truthy
+          end
+
+          # Test that the system path isn't clobbered
+          app.run_multi("which bash") do |out, status|
+            expect(out.strip).to eq("/bin/bash")
+            expect(status.success?).to be_truthy
+          end
+
+          # Verify gem installation location does not change
+          # and binstubs are on the path
+          app.run_multi("which -a rake") do |out, status|
+            # Gem rake version
+            expect(out).to include("/app/.heroku/ruby/gems/bin/rake")
+            expect(status.success?).to be_truthy
+          end
+
+          # Test deploys twice without error
+          app.commit!
+          app.push!
+
+          # Test uses cache after re-deploy
+          expect(app.output).to match("Using rake")
+        end
+      end
+    end
+
+    it "installs node and yarn and calls assets:precompile" do
+      skip("Must set HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
+
+      Hatchet::Runner.new("minimal_webpacker", run_multi: true).tap do |app|
+        app.before_deploy do
+          Pathname(Dir.pwd).join("Procfile").write <<~EOM
+            web: # No-op, needed so we can scale up for run_multi
+          EOM
+        end
+        app.deploy do
+          # This output comes from the heroku/nodejs buildpack
+          expect(app.output).to include("installing yarn")
+
+          # This output comes from the Ruby buildpack
+          expect(app.output).to include("Installing rake")
+
+          # This output comes from the contents of the Rakefile
+          # https://github.com/sharpstone/minimal_webpacker/blob/master/Rakefile
+          expect(app.output).to include("THE TASK ASSETS:PRECOMPILE WAS CALLED")
+          expect(app.output).to include("THE TASK ASSETS:CLEAN WAS CALLED")
+
+          app.run_multi("which node") do |out, status|
+            expect(out.strip).to_not be_empty
+            expect(status.success?).to be_truthy
+          end
+
+          app.run_multi("which yarn") do |out, status|
+            expect(out.strip).to_not be_empty
+            expect(status.success?).to be_truthy
+          end
+        end
+      end
+    end
+
+    # https://github.com/heroku/heroku-buildpack-ruby/pull/124
+    it "nokogiri should use the system libxml2" do
+      Hatchet::Runner.new("default_ruby").tap do |app|
+        app.before_deploy do
+          dir = Pathname(Dir.pwd)
+          dir.join("Gemfile").write <<~EOM
+            source "https://rubygems.org"
+
+            gem "nokogiri", "1.6.0"
+          EOM
+
+          dir.join("Gemfile.lock").write <<~EOM
+            GEM
+              remote: https://rubygems.org/
+              specs:
+                mini_portile (0.5.1)
+                nokogiri (1.6.0)
+                  mini_portile (~> 0.5.0)
+
+            PLATFORMS
+              ruby
+
+            DEPENDENCIES
+              nokogiri (= 1.6.0)
+          EOM
+        end
+
+        app.deploy do
+          expect(app.output).to match("nokogiri")
+
+          expect(
+            app.run(%q{ruby -rnokogiri -e 'puts "Using system libxml2: #{Nokogiri::VersionInfo.new.libxml2_using_system?}"'})
+          ).to match("Using system libxml2: true")
+          expect($?.success?).to be_truthy
+        end
       end
     end
   end

--- a/spec/unit/assets_precompile_spec.rb
+++ b/spec/unit/assets_precompile_spec.rb
@@ -2,70 +2,72 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "assets_precompile" do
-  it "streams the contents of the rake task to the output" do
-    Hatchet::Runner.new("default_ruby").in_directory do
-      dir = Pathname(Dir.pwd)
-      dir.join("Rakefile").write <<~EOM
-        task "assets:precompile" do
-          puts "woop woop precompile worked"
+module HerokuBuildpackRuby
+  RSpec.describe "assets_precompile" do
+    it "streams the contents of the rake task to the output" do
+      Hatchet::Runner.new("default_ruby").in_directory do
+        dir = Pathname(Dir.pwd)
+        dir.join("Rakefile").write <<~EOM
+          task "assets:precompile" do
+            puts "woop woop precompile worked"
+          end
+
+          task "assets:clean" do
+            puts "woop woop clean worked"
+          end
+        EOM
+
+        user_comms = UserComms::Null.new
+        Bundler.with_original_env do
+          AssetsPrecompile.new(
+            has_assets_precompile: true,
+            has_assets_clean: true,
+            user_comms: user_comms,
+            app_dir: dir,
+          ).call
         end
 
-        task "assets:clean" do
-          puts "woop woop clean worked"
-        end
-      EOM
+        expect(user_comms.to_string).to include("rake assets:precompile")
+        expect(user_comms.to_string).to include("woop woop precompile worked")
+        expect(user_comms.to_string).to include("woop woop clean worked")
+      end
+    end
 
-      user_comms = HerokuBuildpackRuby::UserComms::Null.new
-      Bundler.with_original_env do
-        HerokuBuildpackRuby::AssetsPrecompile.new(
-          has_assets_precompile: true,
+    it "skips asset compilation when manifest is found" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+        public_dir = dir.join("public/assets").tap(&:mkpath)
+
+        FileUtils.touch(public_dir.join(".sprockets-manifest-asdf.json"))
+
+        user_comms = UserComms::Null.new
+        AssetsPrecompile.new(
+          has_assets_precompile: false,
           has_assets_clean: true,
           user_comms: user_comms,
           app_dir: dir,
         ).call
+
+        expect(user_comms.to_string).to include("asset manifest found")
       end
-
-      expect(user_comms.to_string).to include("rake assets:precompile")
-      expect(user_comms.to_string).to include("woop woop precompile worked")
-      expect(user_comms.to_string).to include("woop woop clean worked")
     end
-  end
 
-  it "skips asset compilation when manifest is found" do
-    Dir.mktmpdir do |dir|
-      dir = Pathname(dir)
-      public_dir = dir.join("public/assets").tap(&:mkpath)
+    it "skips asset compilation when task is not found" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+        rake = Object.new
+        def rake.detect?(value); return false if value == "assets:precompile"; end
 
-      FileUtils.touch(public_dir.join(".sprockets-manifest-asdf.json"))
+        user_comms = UserComms::Null.new
+        AssetsPrecompile.new(
+          has_assets_precompile: false,
+          has_assets_clean: true,
+          user_comms: user_comms,
+          app_dir: dir,
+        ).call
 
-      user_comms = HerokuBuildpackRuby::UserComms::Null.new
-      HerokuBuildpackRuby::AssetsPrecompile.new(
-        has_assets_precompile: false,
-        has_assets_clean: true,
-        user_comms: user_comms,
-        app_dir: dir,
-      ).call
-
-      expect(user_comms.to_string).to include("asset manifest found")
-    end
-  end
-
-  it "skips asset compilation when task is not found" do
-    Dir.mktmpdir do |dir|
-      dir = Pathname(dir)
-      rake = Object.new
-      def rake.detect?(value); return false if value == "assets:precompile"; end
-
-      user_comms = HerokuBuildpackRuby::UserComms::Null.new
-      HerokuBuildpackRuby::AssetsPrecompile.new(
-        has_assets_precompile: false,
-        has_assets_clean: true,
-        user_comms: user_comms,
-        app_dir: dir,
-      ).call
-
-      expect(user_comms.to_string).to include("Asset compilation skipped")
+        expect(user_comms.to_string).to include("Asset compilation skipped")
+      end
     end
   end
 end

--- a/spec/unit/bash_functions_spec.rb
+++ b/spec/unit/bash_functions_spec.rb
@@ -3,209 +3,210 @@
 require_relative "../spec_helper.rb"
 
 
-RSpec.describe "bash_functions.sh" do
-  def exec_with_bash_functions(code, stack: "heroku-18")
-    contents = <<~EOM
-      #! /usr/bin/env bash
-      set -eu
+module HerokuBuildpackRuby
+  RSpec.describe "bash_functions.sh" do
+    def exec_with_bash_functions(code, stack: "heroku-18")
+      contents = <<~EOM
+        #! /usr/bin/env bash
+        set -eu
 
-      STACK="#{stack}"
+        STACK="#{stack}"
 
-      #{bash_functions_file.read}
+        #{bash_functions_file.read}
 
-      #{code}
-    EOM
+        #{code}
+      EOM
 
-    file = Tempfile.new
-    file.write(contents)
-    file.close
-    FileUtils.chmod("+x", file.path)
+      file = Tempfile.new
+      file.write(contents)
+      file.close
+      FileUtils.chmod("+x", file.path)
 
-    out = nil
-    success = false
-    begin
-      Timeout.timeout(60) do
-        out = `#{file.path} 2>&1`.strip
-        success = $?.success?
-      end
-    rescue Timeout::Error
-      out = "Command timed out"
+      out = nil
       success = false
+      begin
+        Timeout.timeout(60) do
+          out = `#{file.path} 2>&1`.strip
+          success = $?.success?
+        end
+      rescue Timeout::Error
+        out = "Command timed out"
+        success = false
+      end
+      unless success
+        message = <<~EOM
+          Contents:
+
+          #{contents.lines.map.with_index { |line, number| "  #{number.next} #{line.chomp}"}.join("\n") }
+
+          Expected running script to succeed, but it did not
+
+          Output:
+
+            #{out}
+        EOM
+
+        raise message
+      end
+      out
     end
-    unless success
-      message = <<~EOM
-        Contents:
 
-        #{contents.lines.map.with_index { |line, number| "  #{number.next} #{line.chomp}"}.join("\n") }
+    it "Downloads a ruby binary" do
+      Dir.mktmpdir do |dir|
+        exec_with_bash_functions <<~EOM
 
-        Expected running script to succeed, but it did not
+          download_ruby "2.6.6" "#{dir}"
+        EOM
 
-        Output:
+        entries = Dir.entries(dir) - [".", ".."]
 
-          #{out}
-      EOM
-
-      raise message
+        expect(entries.sort).to eq(["bin", "include", "lib", "ruby.tgz", "share"])
+      end
     end
-    out
-  end
 
-  it "Downloads a ruby binary" do
-    Dir.mktmpdir do |dir|
-      exec_with_bash_functions <<~EOM
-
-        download_ruby "2.6.6" "#{dir}"
+    it "parses toml files" do
+      out = exec_with_bash_functions <<~EOM
+        ruby_version_from_toml "#{root_dir.join("buildpack.toml")}"
       EOM
 
-      entries = Dir.entries(dir) - [".", ".."]
-
-      expect(entries.sort).to eq(["bin", "include", "lib", "ruby.tgz", "share"])
+      expect(out).to eq(RubyDetectVersion::DEFAULT)
     end
-  end
 
-  it "parses toml files" do
-    out = exec_with_bash_functions <<~EOM
-      ruby_version_from_toml "#{root_dir.join("buildpack.toml")}"
-    EOM
+    it "downloads ruby to BUILDPACK_DIR vendor directory" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
 
-    expect(out).to eq(HerokuBuildpackRuby::RubyDetectVersion::DEFAULT)
-  end
+        exec_with_bash_functions(<<~EOM, stack: "heroku-18")
+          BUILDPACK_DIR="#{dir}"
+          download_ruby_version_to_buildpack_vendor "2.6.6"
+        EOM
 
-  it "downloads ruby to BUILDPACK_DIR vendor directory" do
-    Dir.mktmpdir do |dir|
-      dir = Pathname(dir)
-
-      exec_with_bash_functions(<<~EOM, stack: "heroku-18")
-        BUILDPACK_DIR="#{dir}"
-        download_ruby_version_to_buildpack_vendor "2.6.6"
-      EOM
-
-      expect(dir.entries.map(&:to_s)).to include("vendor")
-      expect(dir.join("vendor").entries.map(&:to_s)).to include("ruby")
-      expect(dir.join("vendor", "ruby").entries.map(&:to_s)).to include("heroku-18")
-      expect(dir.join("vendor", "ruby", "heroku-18", "bin").entries.map(&:to_s)).to include("ruby")
+        expect(dir.entries.map(&:to_s)).to include("vendor")
+        expect(dir.join("vendor").entries.map(&:to_s)).to include("ruby")
+        expect(dir.join("vendor", "ruby").entries.map(&:to_s)).to include("heroku-18")
+        expect(dir.join("vendor", "ruby", "heroku-18", "bin").entries.map(&:to_s)).to include("ruby")
+      end
     end
-  end
 
-  it "bootstraps ruby using toml file" do
-    Dir.mktmpdir do |dir|
-      dir = Pathname(dir)
+    it "bootstraps ruby using toml file" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
 
-      FileUtils.cp(
-        root_dir.join("buildpack.toml"), # From
-        dir.join("buildpack.toml") # To
-      )
+        FileUtils.cp(
+          root_dir.join("buildpack.toml"), # From
+          dir.join("buildpack.toml") # To
+        )
 
-      exec_with_bash_functions <<~EOM
-        BUILDPACK_DIR="#{dir}"
-        bootstrap_ruby_to_buildpack_dir
-      EOM
+        exec_with_bash_functions <<~EOM
+          BUILDPACK_DIR="#{dir}"
+          bootstrap_ruby_to_buildpack_dir
+        EOM
 
-      expect(dir.entries.map(&:to_s)).to include("vendor")
-      expect(dir.join("vendor").entries.map(&:to_s)).to include("ruby")
-      expect(dir.join("vendor", "ruby").entries.map(&:to_s)).to include("heroku-18")
-      expect(dir.join("vendor", "ruby", "heroku-18", "bin").entries.map(&:to_s)).to include("ruby")
+        expect(dir.entries.map(&:to_s)).to include("vendor")
+        expect(dir.join("vendor").entries.map(&:to_s)).to include("ruby")
+        expect(dir.join("vendor", "ruby").entries.map(&:to_s)).to include("heroku-18")
+        expect(dir.join("vendor", "ruby", "heroku-18", "bin").entries.map(&:to_s)).to include("ruby")
+      end
     end
-  end
 
-  it "outputs a node+ruby plan when a package.json is present" do
-    Dir.mktmpdir do |dir|
-      build_dir = Pathname(dir)
+    it "outputs a node+ruby plan when a package.json is present" do
+      Dir.mktmpdir do |dir|
+        build_dir = Pathname(dir)
 
-      build_dir.join("package.json").write "{}"
+        build_dir.join("package.json").write "{}"
 
-      plan_path = build_dir.join("plan.toml")
-      exec_with_bash_functions <<~EOM
-        # Stub out the call to `which node` so we can pretend it does NOT exist on the system
-        which_node()
-        {
-          return 1
-        }
-        write_to_build_plan "#{plan_path}" "#{build_dir}"
-      EOM
+        plan_path = build_dir.join("plan.toml")
+        exec_with_bash_functions <<~EOM
+          # Stub out the call to `which node` so we can pretend it does NOT exist on the system
+          which_node()
+          {
+            return 1
+          }
+          write_to_build_plan "#{plan_path}" "#{build_dir}"
+        EOM
 
-      toml = HerokuBuildpackRuby::TOML.load(plan_path.read)
+        toml = TOML.load(plan_path.read)
 
-      expect(toml).to include(provides: [{name: "ruby"}])
-      expect(toml).to include(requires: [{name: "node"}, {name: "ruby"}])
+        expect(toml).to include(provides: [{name: "ruby"}])
+        expect(toml).to include(requires: [{name: "node"}, {name: "ruby"}])
+      end
     end
-  end
 
-  it "does not output node when node is already installed" do
-    Dir.mktmpdir do |dir|
-      build_dir = Pathname(dir)
+    it "does not output node when node is already installed" do
+      Dir.mktmpdir do |dir|
+        build_dir = Pathname(dir)
 
-      build_dir.join("package.json").write "{}"
+        build_dir.join("package.json").write "{}"
 
-      plan_path = build_dir.join("plan.toml")
-      plan_path = build_dir.join("plan.toml")
-      exec_with_bash_functions <<~EOM
-        # Stub out the call to `which node` so we can pretend it exists on the system
-        which_node()
-        {
-          echo "foo"
-          return 0
-        }
-        write_to_build_plan "#{plan_path}" "#{build_dir}"
-      EOM
+        plan_path = build_dir.join("plan.toml")
+        plan_path = build_dir.join("plan.toml")
+        exec_with_bash_functions <<~EOM
+          # Stub out the call to `which node` so we can pretend it exists on the system
+          which_node()
+          {
+            echo "foo"
+            return 0
+          }
+          write_to_build_plan "#{plan_path}" "#{build_dir}"
+        EOM
 
-      toml = HerokuBuildpackRuby::TOML.load(plan_path.read)
+        toml = TOML.load(plan_path.read)
 
-      expect(toml).to include(provides: [{name: "ruby"}])
-      expect(toml).to include(requires: [{name: "ruby"}])
+        expect(toml).to include(provides: [{name: "ruby"}])
+        expect(toml).to include(requires: [{name: "ruby"}])
+      end
     end
-  end
 
-  it "detects if execjs is present" do
-    Dir.mktmpdir do |dir|
-      build_dir = Pathname(dir)
-      package_json = build_dir.join("package.json")
-      expect(package_json).to_not be_file
+    it "detects if execjs is present" do
+      Dir.mktmpdir do |dir|
+        build_dir = Pathname(dir)
+        package_json = build_dir.join("package.json")
+        expect(package_json).to_not be_file
 
-      build_dir.join("Gemfile.lock").write <<~EOM
-        coffee-script (2.4.1)
-          coffee-script-source
-          execjs
-      EOM
+        build_dir.join("Gemfile.lock").write <<~EOM
+          coffee-script (2.4.1)
+            coffee-script-source
+            execjs
+        EOM
 
-      exec_with_bash_functions <<~EOM
-        BUILD_DIR="#{build_dir}"
-        if needs_package_json "$BUILD_DIR"; then
-          echo "{}" > "$BUILD_DIR/package.json"
-        fi
-      EOM
+        exec_with_bash_functions <<~EOM
+          BUILD_DIR="#{build_dir}"
+          if needs_package_json "$BUILD_DIR"; then
+            echo "{}" > "$BUILD_DIR/package.json"
+          fi
+        EOM
 
-      expect(package_json).to be_file
-      expect(package_json.read.strip).to eq("{}")
+        expect(package_json).to be_file
+        expect(package_json.read.strip).to eq("{}")
 
-      build_dir.join("Gemfile.lock").write ""
-      package_json.delete
+        build_dir.join("Gemfile.lock").write ""
+        package_json.delete
 
-      exec_with_bash_functions <<~EOM
-        BUILD_DIR="#{build_dir}"
-        if needs_package_json "$BUILD_DIR"; then
-          echo "{}" > "$BUILD_DIR/package.json"
-        fi
-      EOM
+        exec_with_bash_functions <<~EOM
+          BUILD_DIR="#{build_dir}"
+          if needs_package_json "$BUILD_DIR"; then
+            echo "{}" > "$BUILD_DIR/package.json"
+          fi
+        EOM
 
-      expect(package_json).to_not be_file
+        expect(package_json).to_not be_file
+      end
     end
-  end
 
-  it "outputs a ruby plan" do
-    Dir.mktmpdir do |dir|
-      build_dir = Pathname(dir)
+    it "outputs a ruby plan" do
+      Dir.mktmpdir do |dir|
+        build_dir = Pathname(dir)
 
-      plan_path = build_dir.join("plan.toml")
-      exec_with_bash_functions <<~EOM
-        write_to_build_plan "#{plan_path}" "#{build_dir}"
-      EOM
+        plan_path = build_dir.join("plan.toml")
+        exec_with_bash_functions <<~EOM
+          write_to_build_plan "#{plan_path}" "#{build_dir}"
+        EOM
 
-      toml = HerokuBuildpackRuby::TOML.load(plan_path.read)
+        toml = TOML.load(plan_path.read)
 
-      expect(toml).to include(provides: [{name: "ruby"}])
-      expect(toml).to include(requires: [{name: "ruby"}])
+        expect(toml).to include(provides: [{name: "ruby"}])
+        expect(toml).to include(requires: [{name: "ruby"}])
+      end
     end
   end
 end
-

--- a/spec/unit/bundle_install_spec.rb
+++ b/spec/unit/bundle_install_spec.rb
@@ -2,102 +2,103 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "BundleInstall" do
-  it "sets env vars and does not clear cache if nothing changed" do
-    Hatchet::Runner.new("default_ruby").in_directory_fork do
-      stringio = StringIO.new
-      app_dir = Pathname(Dir.pwd)
-      gems_dir = app_dir.join(".heroku/ruby/gems").tap(&:mkpath)
+module HerokuBuildpackRuby
+  RSpec.describe "BundleInstall" do
+    it "sets env vars and does not clear cache if nothing changed" do
+      Hatchet::Runner.new("default_ruby").in_directory_fork do
+        stringio = StringIO.new
+        app_dir = Pathname(Dir.pwd)
+        gems_dir = app_dir.join(".heroku/ruby/gems").tap(&:mkpath)
 
-      # The Bundler.with_original_env will Reset bundler's env vars since we're running in a `bundle exec` context for tests already
-      Bundler.with_original_env do
-        HerokuBuildpackRuby::BundleInstall.new(
-          app_dir: Dir.pwd,
-          bundle_without_default: "development:test",
-          bundle_install_gems_dir: gems_dir,
-          user_comms: HerokuBuildpackRuby::UserComms::V2.new(stringio)
-        ).call
+        # The Bundler.with_original_env will Reset bundler's env vars since we're running in a `bundle exec` context for tests already
+        Bundler.with_original_env do
+          BundleInstall.new(
+            app_dir: Dir.pwd,
+            bundle_without_default: "development:test",
+            bundle_install_gems_dir: gems_dir,
+            user_comms: UserComms::V2.new(stringio)
+          ).call
 
-        expect(stringio.string).to include("bundle install")
-        expect(stringio.string).to include("Fetching")
-        expect(stringio.string).to include("Cleaning up the bundler cache")
-        expect(stringio.string).to include("Fetching rack")
+          expect(stringio.string).to include("bundle install")
+          expect(stringio.string).to include("Fetching")
+          expect(stringio.string).to include("Cleaning up the bundler cache")
+          expect(stringio.string).to include("Fetching rack")
 
-        expect(ENV.key?("BUNDLE_DEPLOYMENT")).to be_truthy
+          expect(ENV.key?("BUNDLE_DEPLOYMENT")).to be_truthy
 
-        expect(ENV["GEM_PATH"]).to include(gems_dir.to_s)
-        expect(ENV["BUNDLE_BIN"]).to include(gems_dir.join("bin").to_s)
-        expect(ENV["BUNDLE_PATH"]).to include(gems_dir.to_s)
-        expect(ENV["PATH"]).to include(gems_dir.join("bin").to_s)
+          expect(ENV["GEM_PATH"]).to include(gems_dir.to_s)
+          expect(ENV["BUNDLE_BIN"]).to include(gems_dir.join("bin").to_s)
+          expect(ENV["BUNDLE_PATH"]).to include(gems_dir.to_s)
+          expect(ENV["PATH"]).to include(gems_dir.join("bin").to_s)
 
-        expect(ENV["BUNDLE_WITHOUT"]).to eq("development:test")
-        expect(ENV["BUNDLE_GEMFILE"]).to eq(app_dir.join("Gemfile").to_s)
+          expect(ENV["BUNDLE_WITHOUT"]).to eq("development:test")
+          expect(ENV["BUNDLE_GEMFILE"]).to eq(app_dir.join("Gemfile").to_s)
 
-        # Test that the cache is not called unless gems were fetched
-        stringio.reopen
-        HerokuBuildpackRuby::BundleInstall.new(
-          app_dir: Dir.pwd,
-          bundle_without_default: "development:test",
-          bundle_install_gems_dir: gems_dir,
-          user_comms: HerokuBuildpackRuby::UserComms::V2.new(stringio)
-        ).call
+          # Test that the cache is not called unless gems were fetched
+          stringio.reopen
+          BundleInstall.new(
+            app_dir: Dir.pwd,
+            bundle_without_default: "development:test",
+            bundle_install_gems_dir: gems_dir,
+            user_comms: UserComms::V2.new(stringio)
+          ).call
 
-        expect(stringio.string).to include("bundle install")
-        expect(stringio.string).to include("Skipping cleaning")
+          expect(stringio.string).to include("bundle install")
+          expect(stringio.string).to include("Skipping cleaning")
 
-        expect(stringio.string).to_not include("Fetching")
-        expect(stringio.string).to_not include("Cleaning up the bundler cache")
+          expect(stringio.string).to_not include("Fetching")
+          expect(stringio.string).to_not include("Cleaning up the bundler cache")
+        end
       end
     end
-  end
 
-  it "handles BUNDLE_WITHOUT with a space" do
-    Hatchet::Runner.new("default_ruby").in_directory_fork do
-      stringio = StringIO.new
-      app_dir = Pathname(Dir.pwd)
-      gems_dir = app_dir.join(".heroku/ruby/gems").tap(&:mkpath)
+    it "handles BUNDLE_WITHOUT with a space" do
+      Hatchet::Runner.new("default_ruby").in_directory_fork do
+        stringio = StringIO.new
+        app_dir = Pathname(Dir.pwd)
+        gems_dir = app_dir.join(".heroku/ruby/gems").tap(&:mkpath)
 
-      Bundler.with_original_env do
-        ENV["BUNDLE_WITHOUT"] = "i have spaces"
-        HerokuBuildpackRuby::BundleInstall.new(
-          app_dir: Dir.pwd,
-          bundle_without_default: "development:test",
-          bundle_install_gems_dir: gems_dir,
-          user_comms: HerokuBuildpackRuby::UserComms::V2.new(stringio)
-        ).call
+        Bundler.with_original_env do
+          ENV["BUNDLE_WITHOUT"] = "i have spaces"
+          BundleInstall.new(
+            app_dir: Dir.pwd,
+            bundle_without_default: "development:test",
+            bundle_install_gems_dir: gems_dir,
+            user_comms: UserComms::V2.new(stringio)
+          ).call
 
-        expect(stringio.string).to include("Warning")
-        expect(stringio.string).to include('BUNDLE_WITHOUT="i:have:spaces"')
+          expect(stringio.string).to include("Warning")
+          expect(stringio.string).to include('BUNDLE_WITHOUT="i:have:spaces"')
+        end
       end
     end
-  end
 
-  it "handles user defined BUNDLE_WITHOUT" do
-    Hatchet::Runner.new("default_ruby").in_directory_fork do
-      stringio = StringIO.new
-      app_dir = Pathname(Dir.pwd)
-      gems_dir = app_dir.join(".heroku/ruby/gems").tap(&:mkpath)
+    it "handles user defined BUNDLE_WITHOUT" do
+      Hatchet::Runner.new("default_ruby").in_directory_fork do
+        stringio = StringIO.new
+        app_dir = Pathname(Dir.pwd)
+        gems_dir = app_dir.join(".heroku/ruby/gems").tap(&:mkpath)
 
-      Dir.mktmpdir do |dir|
-        dir = Pathname(dir)
-        dir.join("BUNDLE_WITHOUT").write("i have spaces")
-        HerokuBuildpackRuby::UserEnv.parse(dir)
-      end
+        Dir.mktmpdir do |dir|
+          dir = Pathname(dir)
+          dir.join("BUNDLE_WITHOUT").write("i have spaces")
+          UserEnv.parse(dir)
+        end
 
-      Bundler.with_original_env do
-        HerokuBuildpackRuby::BundleInstall.new(
-          app_dir: Dir.pwd,
-          bundle_without_default: "development:test",
-          bundle_install_gems_dir: gems_dir,
-          user_comms: HerokuBuildpackRuby::UserComms::V2.new(stringio)
-        ).call
+        Bundler.with_original_env do
+          BundleInstall.new(
+            app_dir: Dir.pwd,
+            bundle_without_default: "development:test",
+            bundle_install_gems_dir: gems_dir,
+            user_comms: UserComms::V2.new(stringio)
+          ).call
 
-        puts stringio.string
-        expect(stringio.string).to include("Warning")
-        expect(stringio.string).to include('BUNDLE_WITHOUT="i:have:spaces"')
-        expect(stringio.string).to include('heroku config:set BUNDLE_WITHOUT="i:have:spaces"')
-      ensure
-        HerokuBuildpackRuby::UserEnv.clear
+          expect(stringio.string).to include("Warning")
+          expect(stringio.string).to include('BUNDLE_WITHOUT="i:have:spaces"')
+          expect(stringio.string).to include('heroku config:set BUNDLE_WITHOUT="i:have:spaces"')
+        ensure
+          UserEnv.clear
+        end
       end
     end
   end

--- a/spec/unit/bundler_detect_version_spec.rb
+++ b/spec/unit/bundler_detect_version_spec.rb
@@ -2,65 +2,67 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "bundler detect version" do
-  it "detects major bundler version 2" do
-    Dir.mktmpdir do |dir|
-      lockfile_path = Pathname(dir).join("Gemfile.lock")
-      lockfile_path.write <<~EOM
-        BUNDLED WITH
-           2.1.4
-      EOM
+module HerokuBuildpackRuby
+  RSpec.describe "bundler detect version" do
+    it "detects major bundler version 2" do
+      Dir.mktmpdir do |dir|
+        lockfile_path = Pathname(dir).join("Gemfile.lock")
+        lockfile_path.write <<~EOM
+          BUNDLED WITH
+             2.1.4
+        EOM
 
-      detect = HerokuBuildpackRuby::BundlerDetectVersion.new(
-        lockfile_path: lockfile_path
-      ).call
+        detect = BundlerDetectVersion.new(
+          lockfile_path: lockfile_path
+        ).call
 
-      expect(detect.version).to eq(HerokuBuildpackRuby::BundlerDetectVersion::BUNDLER_VERSIONS["2"])
+        expect(detect.version).to eq(BundlerDetectVersion::BUNDLER_VERSIONS["2"])
+      end
     end
-  end
 
-  it "detects major bundler version 1" do
-    Dir.mktmpdir do |dir|
-      lockfile_path = Pathname(dir).join("Gemfile.lock")
-      lockfile_path.write <<~EOM
-        BUNDLED WITH
-           1.1.4
-      EOM
+    it "detects major bundler version 1" do
+      Dir.mktmpdir do |dir|
+        lockfile_path = Pathname(dir).join("Gemfile.lock")
+        lockfile_path.write <<~EOM
+          BUNDLED WITH
+             1.1.4
+        EOM
 
-      detect = HerokuBuildpackRuby::BundlerDetectVersion.new(
-        lockfile_path: lockfile_path
-      ).call
+        detect = BundlerDetectVersion.new(
+          lockfile_path: lockfile_path
+        ).call
 
-      expect(detect.version).to eq(HerokuBuildpackRuby::BundlerDetectVersion::BUNDLER_VERSIONS["1"])
+        expect(detect.version).to eq(BundlerDetectVersion::BUNDLER_VERSIONS["1"])
+      end
     end
-  end
 
-  it "detects default" do
-    Dir.mktmpdir do |dir|
-      lockfile_path = Pathname(dir).join("Gemfile.lock")
-      lockfile_path.write <<~EOM
-        BUNDLED WITH
-           1.1.4
-      EOM
+    it "detects default" do
+      Dir.mktmpdir do |dir|
+        lockfile_path = Pathname(dir).join("Gemfile.lock")
+        lockfile_path.write <<~EOM
+          BUNDLED WITH
+             1.1.4
+        EOM
 
-      detect = HerokuBuildpackRuby::BundlerDetectVersion.new(
-        lockfile_path: lockfile_path
-      ).call
+        detect = BundlerDetectVersion.new(
+          lockfile_path: lockfile_path
+        ).call
 
-      expect(detect.version).to eq(HerokuBuildpackRuby::BundlerDetectVersion::BUNDLER_VERSIONS["1"])
+        expect(detect.version).to eq(BundlerDetectVersion::BUNDLER_VERSIONS["1"])
+      end
     end
-  end
 
-  it "detects version default when not specified" do
-    Dir.mktmpdir do |dir|
-      lockfile_path = Pathname(dir).join("Gemfile.lock")
-      lockfile_path.write ""
+    it "detects version default when not specified" do
+      Dir.mktmpdir do |dir|
+        lockfile_path = Pathname(dir).join("Gemfile.lock")
+        lockfile_path.write ""
 
-      detect = HerokuBuildpackRuby::BundlerDetectVersion.new(
-        lockfile_path: lockfile_path
-      ).call
+        detect = BundlerDetectVersion.new(
+          lockfile_path: lockfile_path
+        ).call
 
-      expect(detect.version).to eq(HerokuBuildpackRuby::BundlerDetectVersion::BUNDLER_VERSIONS[nil])
+        expect(detect.version).to eq(BundlerDetectVersion::BUNDLER_VERSIONS[nil])
+      end
     end
   end
 end

--- a/spec/unit/bundler_lockfile_parser_spec.rb
+++ b/spec/unit/bundler_lockfile_parser_spec.rb
@@ -2,82 +2,84 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "lockfile parser" do
-  it "can read dependencies" do
-    Dir.mktmpdir do |dir|
-      dir = Pathname(dir)
-      lockfile = dir.join("Gemfile.lock")
-      lockfile.write <<~EOM
-        PATH
-          remote: .
-          specs:
-            mini_histogram (0.3.1)
+module HerokuBuildpackRuby
+  RSpec.describe "lockfile parser" do
+    it "can read dependencies" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+        lockfile = dir.join("Gemfile.lock")
+        lockfile.write <<~EOM
+          PATH
+            remote: .
+            specs:
+              mini_histogram (0.3.1)
 
-        GEM
-          remote: https://rubygems.org/
-          specs:
-            benchmark-ips (2.7.2)
-            m (1.5.1)
-              method_source (>= 0.6.7)
-              rake (>= 0.9.2.2)
-            method_source (0.9.2)
-            minitest (5.14.0)
-            rake (12.3.3)
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              benchmark-ips (2.7.2)
+              m (1.5.1)
+                method_source (>= 0.6.7)
+                rake (>= 0.9.2.2)
+              method_source (0.9.2)
+              minitest (5.14.0)
+              rake (12.3.3)
 
-        PLATFORMS
-          ruby
+          PLATFORMS
+            ruby
 
-        DEPENDENCIES
-          benchmark-ips
-          m
-          mini_histogram!
-          minitest (~> 5.0)
-          rake (~> 12.0)
+          DEPENDENCIES
+            benchmark-ips
+            m
+            mini_histogram!
+            minitest (~> 5.0)
+            rake (~> 12.0)
 
-        BUNDLED WITH
-           2.1.4
-      EOM
+          BUNDLED WITH
+             2.1.4
+        EOM
 
-      # We need bundler internal locations
-      #
-      # We could use the already installed bundler on disk,
-      # but `which bundler` points to the binstub and not to
-      # the install location which may be different, it's easier
-      # to just download a copy every time
-      bundler_install_dir = dir.join("bundler").tap(&:mkpath)
-      HerokuBuildpackRuby::BundlerDownload.new(
-        version: "2.1.4",
-        install_dir: bundler_install_dir
-      ).call
-
-      # We need to be able to make sure our code works
-      # when no bundler version is loaded, to simulate this
-      # we write a script to disk then execute it with a raw
-      # `ruby` command.
-      script = dir.join("script.rb")
-      script.write <<~EOM
-        $LOAD_PATH << "#{root_dir.join('lib')}"
-
-        raise "This constant should not be loaded yet Bundler::LockfileParser" if defined?(Bundler::LockfileParser)
-
-        require 'heroku_buildpack_ruby'
-
-        dependencies = HerokuBuildpackRuby::BundlerLockfileParser.new(
-          gemfile_lock_path: "#{lockfile}",
-          bundler_install_dir: "#{bundler_install_dir}",
+        # We need bundler internal locations
+        #
+        # We could use the already installed bundler on disk,
+        # but `which bundler` points to the binstub and not to
+        # the install location which may be different, it's easier
+        # to just download a copy every time
+        bundler_install_dir = dir.join("bundler").tap(&:mkpath)
+        BundlerDownload.new(
+          version: "2.1.4",
+          install_dir: bundler_install_dir
         ).call
 
-        puts "Has minitest: \#{dependencies.has_gem?("minitest")}"
-        puts "Minitest Version: \#{dependencies.version("minitest")}"
-        puts "Windows: \#{!!dependencies.windows?}"
-      EOM
+        # We need to be able to make sure our code works
+        # when no bundler version is loaded, to simulate this
+        # we write a script to disk then execute it with a raw
+        # `ruby` command.
+        script = dir.join("script.rb")
+        script.write <<~EOM
+          $LOAD_PATH << "#{root_dir.join('lib')}"
 
-      Bundler.with_original_env do
-        out = HerokuBuildpackRuby::Bash.new("ruby #{script}").run!
+          raise "This constant should not be loaded yet Bundler::LockfileParser" if defined?(Bundler::LockfileParser)
 
-        expect(out).to include("Has minitest: true")
-        expect(out).to include("Minitest Version: 5.14.0")
-        expect(out).to include("Windows: false")
+          require 'heroku_buildpack_ruby'
+
+          dependencies = HerokuBuildpackRuby::BundlerLockfileParser.new(
+            gemfile_lock_path: "#{lockfile}",
+            bundler_install_dir: "#{bundler_install_dir}",
+          ).call
+
+          puts "Has minitest: \#{dependencies.has_gem?("minitest")}"
+          puts "Minitest Version: \#{dependencies.version("minitest")}"
+          puts "Windows: \#{!!dependencies.windows?}"
+        EOM
+
+        Bundler.with_original_env do
+          out = Bash.new("ruby #{script}").run!
+
+          expect(out).to include("Has minitest: true")
+          expect(out).to include("Minitest Version: 5.14.0")
+          expect(out).to include("Windows: false")
+        end
       end
     end
   end

--- a/spec/unit/bundler_strip_bundled_with_spec.rb
+++ b/spec/unit/bundler_strip_bundled_with_spec.rb
@@ -2,21 +2,23 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "BundlerStripBundledWith" do
-  it "removes bundled with contents from disk" do
-    Tempfile.create("Gemfile.lock") do |lockfile|
-      lockfile = Pathname(lockfile)
-      lockfile.write <<~EOM
-        before
-        BUNDLED WITH
-           2.1.4
-        after
-      EOM
+module HerokuBuildpackRuby
+  RSpec.describe "BundlerStripBundledWith" do
+    it "removes bundled with contents from disk" do
+      Tempfile.create("Gemfile.lock") do |lockfile|
+        lockfile = Pathname(lockfile)
+        lockfile.write <<~EOM
+          before
+          BUNDLED WITH
+             2.1.4
+          after
+        EOM
 
-      expect(lockfile.read).to include("BUNDLED WITH")
-      HerokuBuildpackRuby::BundlerStripBundledWith.new(lockfile_path: lockfile).call
-      expect(lockfile.read).to_not include("BUNDLED WITH")
-      expect(lockfile.read.strip).to eq("before\n\nafter")
+        expect(lockfile.read).to include("BUNDLED WITH")
+        BundlerStripBundledWith.new(lockfile_path: lockfile).call
+        expect(lockfile.read).to_not include("BUNDLED WITH")
+        expect(lockfile.read.strip).to eq("before\n\nafter")
+      end
     end
   end
 end

--- a/spec/unit/cache_copy_spec.rb
+++ b/spec/unit/cache_copy_spec.rb
@@ -2,28 +2,30 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "cache copy" do
-  it "" do
-    Dir.mktmpdir do |dir|
-      dir = Pathname(dir)
-      dest_dir = dir.join("foo").tap(&:mkpath)
-      cache_dir = dir.join("cache").tap(&:mkpath)
+module HerokuBuildpackRuby
+  RSpec.describe "cache copy" do
+    it "" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+        dest_dir = dir.join("foo").tap(&:mkpath)
+        cache_dir = dir.join("cache").tap(&:mkpath)
 
-      expect(dest_dir).to be_empty
-      HerokuBuildpackRuby::CacheCopy.new(cache_dir: cache_dir, dest_dir: dest_dir).call do |block_value|
-        dest_dir.join("hello.txt").write "hello world"
+        expect(dest_dir).to be_empty
+        CacheCopy.new(cache_dir: cache_dir, dest_dir: dest_dir).call do |block_value|
+          dest_dir.join("hello.txt").write "hello world"
 
+          expect(dest_dir.entries.map(&:to_s)).to include("hello.txt")
+          expect(dest_dir).to eq(block_value)
+        end
         expect(dest_dir.entries.map(&:to_s)).to include("hello.txt")
-        expect(dest_dir).to eq(block_value)
-      end
-      expect(dest_dir.entries.map(&:to_s)).to include("hello.txt")
-      expect(cache_dir.entries.map(&:to_s)).to include("hello.txt")
+        expect(cache_dir.entries.map(&:to_s)).to include("hello.txt")
 
-      different_dest_dir = dir.join("bar").tap(&:mkpath)
+        different_dest_dir = dir.join("bar").tap(&:mkpath)
 
-      expect(different_dest_dir).to be_empty
-      HerokuBuildpackRuby::CacheCopy.new(cache_dir: cache_dir, dest_dir: different_dest_dir).call do
-        expect(different_dest_dir.entries.map(&:to_s)).to include("hello.txt")
+        expect(different_dest_dir).to be_empty
+        CacheCopy.new(cache_dir: cache_dir, dest_dir: different_dest_dir).call do
+          expect(different_dest_dir.entries.map(&:to_s)).to include("hello.txt")
+        end
       end
     end
   end

--- a/spec/unit/env_proxy_spec.rb
+++ b/spec/unit/env_proxy_spec.rb
@@ -2,244 +2,246 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "env proxy" do
-  before(:all) do
-    HerokuBuildpackRuby::EnvProxy.register_layer(:foo, build: true, cache: true,  launch: true)
-    HerokuBuildpackRuby::EnvProxy.register_layer(:bar, build: true, cache: true,  launch: true)
-  end
-
-  after(:all) do
-    HerokuBuildpackRuby::EnvProxy.delete_layer(:foo)
-    HerokuBuildpackRuby::EnvProxy.delete_layer(:bar)
-  end
-
-  def unique_env_key
-    while key = SecureRandom.hex and ENV.key?(key)
+module HerokuBuildpackRuby
+  RSpec.describe "env proxy" do
+    before(:all) do
+      EnvProxy.register_layer(:foo, build: true, cache: true,  launch: true)
+      EnvProxy.register_layer(:bar, build: true, cache: true,  launch: true)
     end
-    key
-  end
 
-  it "does not let special characters in env vars affect exporting" do
-    env_var = HerokuBuildpackRuby::EnvProxy.path(unique_env_key)
-    ENV[env_var.key] = "a\nb"
-    env_var.prepend(foo: "c")
+    after(:all) do
+      EnvProxy.delete_layer(:foo)
+      EnvProxy.delete_layer(:bar)
+    end
 
-    expect(env_var.value).to eq("c:a\nb")
-    expect(env_var.to_export).to eq(%Q{export #{env_var.key}="c:$#{env_var.key}"})
-  ensure
-    HerokuBuildpackRuby::EnvProxy.delete(env_var)
-  end
+    def unique_env_key
+      while key = SecureRandom.hex and ENV.key?(key)
+      end
+      key
+    end
 
-  it "lol example" do
-    env_var = HerokuBuildpackRuby::EnvProxy.path(unique_env_key)
-    env_var.prepend(foo: ["/app/lol", "haha"])
-    env_var.prepend(bar: "/app/rofl")
+    it "does not let special characters in env vars affect exporting" do
+      env_var = EnvProxy.path(unique_env_key)
+      ENV[env_var.key] = "a\nb"
+      env_var.prepend(foo: "c")
 
-    profile_d = Tempfile.new
-    export = Tempfile.new
-    env_var.write_exports(
-      profile_d_path: profile_d.path,
-      export_path: export.path,
-      app_dir: "/app"
-    )
+      expect(env_var.value).to eq("c:a\nb")
+      expect(env_var.to_export).to eq(%Q{export #{env_var.key}="c:$#{env_var.key}"})
+    ensure
+      EnvProxy.delete(env_var)
+    end
 
-    expect(
-      File.read(profile_d).strip
-    ).to eq(%Q{export #{env_var.key}="$HOME/rofl:$HOME/lol:haha:$#{env_var.key}"})
-  ensure
-    HerokuBuildpackRuby::EnvProxy.delete(env_var)
-  end
+    it "lol example" do
+      env_var = EnvProxy.path(unique_env_key)
+      env_var.prepend(foo: ["/app/lol", "haha"])
+      env_var.prepend(bar: "/app/rofl")
 
-  it "exports to a file" do
-    env_var_1 = HerokuBuildpackRuby::EnvProxy.value(unique_env_key)
-    env_var_1.set(
-      bar: "/app/cinco"
-    )
-
-    env_var_2 = HerokuBuildpackRuby::EnvProxy.path(unique_env_key)
-    env_var_2.prepend(
-      bar: "/app/river"
-    )
-    profile_d = Tempfile.new
-    export = Tempfile.new
-    HerokuBuildpackRuby::EnvProxy.export(
-      profile_d_path: profile_d.path,
-      export_path: export.path,
-      app_dir: "/app"
-    )
-
-    expect(File.read(export.path)).to include(%Q{export #{env_var_1.key}="/app/cinco"\n})
-    expect(File.read(export.path)).to include(%Q{export #{env_var_2.key}="/app/river:$#{env_var_2.key}"\n})
-
-    expect(File.read(profile_d.path)).to include(%Q{export #{env_var_1.key}="$HOME/cinco"\n})
-    expect(File.read(profile_d.path)).to include(%Q{export #{env_var_2.key}="$HOME/river:$#{env_var_2.key}"\n})
-
-    Dir.mktmpdir do |dir|
-      layers_dir = Pathname(dir)
-      HerokuBuildpackRuby::EnvProxy.write_layers(
-        layers_dir: layers_dir,
+      profile_d = Tempfile.new
+      export = Tempfile.new
+      env_var.write_exports(
+        profile_d_path: profile_d.path,
+        export_path: export.path,
+        app_dir: "/app"
       )
 
-      toml_hash = HerokuBuildpackRuby::TOML.load(layers_dir.join("foo.toml").read)
-      expect(toml_hash).to eq({build: true, cache: true, launch: true})
-
-      expect(layers_dir.join("bar/env.launch").entries.map(&:to_s)).to include("#{env_var_1.key}.override")
-
-      expect(layers_dir.join("bar/env.launch/#{env_var_1.key}.override").read).to eq("/app/cinco")
-      expect(layers_dir.join("bar/env.launch/#{env_var_2.key}").read).to eq("/app/river")
-
-      expect(layers_dir.join("bar/env.build/#{env_var_1.key}.override").read).to eq("/app/cinco")
-      expect(layers_dir.join("bar/env.build/#{env_var_2.key}").read).to eq("/app/river")
+      expect(
+        File.read(profile_d).strip
+      ).to eq(%Q{export #{env_var.key}="$HOME/rofl:$HOME/lol:haha:$#{env_var.key}"})
+    ensure
+      EnvProxy.delete(env_var)
     end
-  ensure
-    HerokuBuildpackRuby::EnvProxy.delete(env_var_1) if env_var_1
-    HerokuBuildpackRuby::EnvProxy.delete(env_var_2) if env_var_2
-  end
 
-  it "prevents setting values to two different env vars" do
-    env_var = HerokuBuildpackRuby::EnvProxy.value(unique_env_key)
-    expect {
-      env_var.set(
-        foo: "/hi/there/hi",
-        bar: "i am different"
+    it "exports to a file" do
+      env_var_1 = EnvProxy.value(unique_env_key)
+      env_var_1.set(
+        bar: "/app/cinco"
       )
-    }.to raise_error(/cannot set the same ENV var/)
-  end
 
-  it "default will use the user env value if one is present" do
-    key = unique_env_key
-    Dir.mktmpdir do |dir|
-      dir = Pathname(dir)
-      dir.join(key).write("lol")
+      env_var_2 = EnvProxy.path(unique_env_key)
+      env_var_2.prepend(
+        bar: "/app/river"
+      )
+      profile_d = Tempfile.new
+      export = Tempfile.new
+      EnvProxy.export(
+        profile_d_path: profile_d.path,
+        export_path: export.path,
+        app_dir: "/app"
+      )
 
-      user_env = HerokuBuildpackRuby::UserEnvFromDir.new.parse(dir)
-      env_var = HerokuBuildpackRuby::EnvProxy.default(key, user_env: user_env)
+      expect(File.read(export.path)).to include(%Q{export #{env_var_1.key}="/app/cinco"\n})
+      expect(File.read(export.path)).to include(%Q{export #{env_var_2.key}="/app/river:$#{env_var_2.key}"\n})
+
+      expect(File.read(profile_d.path)).to include(%Q{export #{env_var_1.key}="$HOME/cinco"\n})
+      expect(File.read(profile_d.path)).to include(%Q{export #{env_var_2.key}="$HOME/river:$#{env_var_2.key}"\n})
+
+      Dir.mktmpdir do |dir|
+        layers_dir = Pathname(dir)
+        EnvProxy.write_layers(
+          layers_dir: layers_dir,
+        )
+
+        toml_hash = TOML.load(layers_dir.join("foo.toml").read)
+        expect(toml_hash).to eq({build: true, cache: true, launch: true})
+
+        expect(layers_dir.join("bar/env.launch").entries.map(&:to_s)).to include("#{env_var_1.key}.override")
+
+        expect(layers_dir.join("bar/env.launch/#{env_var_1.key}.override").read).to eq("/app/cinco")
+        expect(layers_dir.join("bar/env.launch/#{env_var_2.key}").read).to eq("/app/river")
+
+        expect(layers_dir.join("bar/env.build/#{env_var_1.key}.override").read).to eq("/app/cinco")
+        expect(layers_dir.join("bar/env.build/#{env_var_2.key}").read).to eq("/app/river")
+      end
+    ensure
+      EnvProxy.delete(env_var_1) if env_var_1
+      EnvProxy.delete(env_var_2) if env_var_2
+    end
+
+    it "prevents setting values to two different env vars" do
+      env_var = EnvProxy.value(unique_env_key)
+      expect {
+        env_var.set(
+          foo: "/hi/there/hi",
+          bar: "i am different"
+        )
+      }.to raise_error(/cannot set the same ENV var/)
+    end
+
+    it "default will use the user env value if one is present" do
+      key = unique_env_key
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+        dir.join(key).write("lol")
+
+        user_env = UserEnvFromDir.new.parse(dir)
+        env_var = EnvProxy.default(key, user_env: user_env)
+        env_var.set_default(
+          foo: "/hi/there/hi",
+        )
+
+        expect(EnvProxy).to include(env_var)
+
+        # Modifies ENV
+        expect(ENV[env_var.key]).to eq("lol")
+        expect(env_var.value).to eq("lol")
+        expect(env_var.to_env).to eq(%Q{#{env_var.key}="lol" })
+      end
+    ensure
+      ENV.delete(key) if key
+    end
+
+    it "default acts like a default" do
+      env_var = EnvProxy.default(unique_env_key)
       env_var.set_default(
         foo: "/hi/there/hi",
       )
 
-      expect(HerokuBuildpackRuby::EnvProxy).to include(env_var)
+      expect(EnvProxy).to include(env_var)
 
       # Modifies ENV
-      expect(ENV[env_var.key]).to eq("lol")
-      expect(env_var.value).to eq("lol")
-      expect(env_var.to_env).to eq(%Q{#{env_var.key}="lol" })
+      expect(ENV[env_var.key]).to eq("/hi/there/hi")
+      expect(env_var.value).to eq("/hi/there/hi")
+      expect(env_var.to_env).to eq(%Q{#{env_var.key}="/hi/there/hi" })
+
+      # Exports for legacy/v2 interface
+      expect(env_var.to_export).to eq(%Q{export #{env_var.key}="${#{env_var.key}:-/hi/there/hi}"})
+
+      expect(env_var.to_export).to eq(%Q{export #{env_var.key}="${#{env_var.key}:-/hi/there/hi}"})
+      expect(env_var.to_export(replace: "/hi", with: "$HOME")).to eq(%Q{export #{env_var.key}="${#{env_var.key}:-$HOME/there/hi}"})
+
+      # Can write to layers for CNB interface
+      Dir.mktmpdir do |dir|
+        layers_dir = Pathname(dir)
+
+        env_var.write_layer(layers_dir: layers_dir)
+
+
+        expect(layers_dir.entries.map(&:to_s)).to include("foo")
+        expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.launch")
+        expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.build")
+
+        expect(layers_dir.join("foo/env.launch/#{env_var.key}.default").read).to eq("/hi/there/hi")
+        expect(layers_dir.join("foo/env.build/#{env_var.key}.default").read).to eq("/hi/there/hi")
+      end
+    ensure
+      EnvProxy.delete(env_var) if env_var
     end
-  ensure
-    ENV.delete(key) if key
-  end
 
-  it "default acts like a default" do
-    env_var = HerokuBuildpackRuby::EnvProxy.default(unique_env_key)
-    env_var.set_default(
-      foo: "/hi/there/hi",
-    )
+    it "value acts like an value-ish" do
+      env_var = EnvProxy.value(unique_env_key)
+      env_var.set(
+        foo: "/hi/there/hi",
+      )
 
-    expect(HerokuBuildpackRuby::EnvProxy).to include(env_var)
+      expect(EnvProxy).to include(env_var)
+      expect(env_var.value).to eq("/hi/there/hi")
+      expect(env_var.to_env).to eq(%Q{#{env_var.key}="/hi/there/hi" })
 
-    # Modifies ENV
-    expect(ENV[env_var.key]).to eq("/hi/there/hi")
-    expect(env_var.value).to eq("/hi/there/hi")
-    expect(env_var.to_env).to eq(%Q{#{env_var.key}="/hi/there/hi" })
+      # Modifies ENV
+      expect(ENV[env_var.key]).to eq("/hi/there/hi")
 
-    # Exports for legacy/v2 interface
-    expect(env_var.to_export).to eq(%Q{export #{env_var.key}="${#{env_var.key}:-/hi/there/hi}"})
+      # Exports for legacy/v2 interface
+      expect(env_var.to_export).to eq(%Q{export #{env_var.key}="/hi/there/hi"})
 
-    expect(env_var.to_export).to eq(%Q{export #{env_var.key}="${#{env_var.key}:-/hi/there/hi}"})
-    expect(env_var.to_export(replace: "/hi", with: "$HOME")).to eq(%Q{export #{env_var.key}="${#{env_var.key}:-$HOME/there/hi}"})
+      expect(env_var.to_export).to eq(%Q{export #{env_var.key}="/hi/there/hi"})
+      expect(env_var.to_export(replace: "/hi", with: "$HOME")).to eq(%Q{export #{env_var.key}="$HOME/there/hi"})
 
-    # Can write to layers for CNB interface
-    Dir.mktmpdir do |dir|
-      layers_dir = Pathname(dir)
+      # Can write to layers for CNB interface
+      Dir.mktmpdir do |dir|
+        layers_dir = Pathname(dir)
 
-      env_var.write_layer(layers_dir: layers_dir)
+        env_var.write_layer(layers_dir: layers_dir)
 
 
-      expect(layers_dir.entries.map(&:to_s)).to include("foo")
-      expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.launch")
-      expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.build")
+        expect(layers_dir.entries.map(&:to_s)).to include("foo")
+        expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.launch")
+        expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.build")
 
-      expect(layers_dir.join("foo/env.launch/#{env_var.key}.default").read).to eq("/hi/there/hi")
-      expect(layers_dir.join("foo/env.build/#{env_var.key}.default").read).to eq("/hi/there/hi")
+        expect(layers_dir.join("foo/env.launch/#{env_var.key}.override").read).to eq("/hi/there/hi")
+        expect(layers_dir.join("foo/env.build/#{env_var.key}.override").read).to eq("/hi/there/hi")
+      end
+    ensure
+      EnvProxy.delete(env_var) if env_var
     end
-  ensure
-    HerokuBuildpackRuby::EnvProxy.delete(env_var) if env_var
-  end
 
-  it "value acts like an value-ish" do
-    env_var = HerokuBuildpackRuby::EnvProxy.value(unique_env_key)
-    env_var.set(
-      foo: "/hi/there/hi",
-    )
+    it "path acts like an array-ish" do
+      env_var = EnvProxy.path(unique_env_key)
+      env_var.prepend(
+        foo: ["/hi/you", "there"],
+        bar: ["how", "are_you"]
+      )
+      expect(EnvProxy).to include(env_var)
 
-    expect(HerokuBuildpackRuby::EnvProxy).to include(env_var)
-    expect(env_var.value).to eq("/hi/there/hi")
-    expect(env_var.to_env).to eq(%Q{#{env_var.key}="/hi/there/hi" })
+      # Modifies ENV
+      expect(ENV[env_var.key]).to eq("/hi/you:there:how:are_you")
+      expect(env_var.value).to eq("/hi/you:there:how:are_you")
+      expect(env_var.to_env).to eq(%Q{#{env_var.key}="/hi/you:there:how:are_you" })
 
-    # Modifies ENV
-    expect(ENV[env_var.key]).to eq("/hi/there/hi")
+      # Exports for legacy/v2 interface
+      expect(env_var.to_export).to include(%Q{export #{env_var.key}="how:are_you:/hi/you:there:$#{env_var.key}"})
 
-    # Exports for legacy/v2 interface
-    expect(env_var.to_export).to eq(%Q{export #{env_var.key}="/hi/there/hi"})
+      expect(env_var.to_export(replace: "/hi", with: "$HOME")).to include(%Q{export #{env_var.key}="how:are_you:$HOME/you:there:$#{env_var.key}"})
 
-    expect(env_var.to_export).to eq(%Q{export #{env_var.key}="/hi/there/hi"})
-    expect(env_var.to_export(replace: "/hi", with: "$HOME")).to eq(%Q{export #{env_var.key}="$HOME/there/hi"})
+      # Can write to layers for CNB interface
+      Dir.mktmpdir do |dir|
+        layers_dir = Pathname(dir)
 
-    # Can write to layers for CNB interface
-    Dir.mktmpdir do |dir|
-      layers_dir = Pathname(dir)
+        env_var.write_layer(layers_dir: layers_dir)
 
-      env_var.write_layer(layers_dir: layers_dir)
+        expect(layers_dir.entries.map(&:to_s)).to include("foo")
+        expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.launch")
+        expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.build")
 
+        expect(layers_dir.join("foo/env.launch/#{env_var.key}").read).to eq("/hi/you:there")
 
-      expect(layers_dir.entries.map(&:to_s)).to include("foo")
-      expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.launch")
-      expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.build")
+        env_var.write_layer(layers_dir: layers_dir)
+        expect(layers_dir.join("bar").entries.map(&:to_s)).to include("env.launch")
+        expect(layers_dir.join("bar").entries.map(&:to_s)).to include("env.build")
 
-      expect(layers_dir.join("foo/env.launch/#{env_var.key}.override").read).to eq("/hi/there/hi")
-      expect(layers_dir.join("foo/env.build/#{env_var.key}.override").read).to eq("/hi/there/hi")
+        expect(layers_dir.join("bar/env.launch/#{env_var.key}").read).to eq("how:are_you")
+      end
+    ensure
+      EnvProxy.delete(env_var) if env_var
     end
-  ensure
-    HerokuBuildpackRuby::EnvProxy.delete(env_var) if env_var
-  end
-
-  it "path acts like an array-ish" do
-    env_var = HerokuBuildpackRuby::EnvProxy.path(unique_env_key)
-    env_var.prepend(
-      foo: ["/hi/you", "there"],
-      bar: ["how", "are_you"]
-    )
-    expect(HerokuBuildpackRuby::EnvProxy).to include(env_var)
-
-    # Modifies ENV
-    expect(ENV[env_var.key]).to eq("/hi/you:there:how:are_you")
-    expect(env_var.value).to eq("/hi/you:there:how:are_you")
-    expect(env_var.to_env).to eq(%Q{#{env_var.key}="/hi/you:there:how:are_you" })
-
-    # Exports for legacy/v2 interface
-    expect(env_var.to_export).to include(%Q{export #{env_var.key}="how:are_you:/hi/you:there:$#{env_var.key}"})
-
-    expect(env_var.to_export(replace: "/hi", with: "$HOME")).to include(%Q{export #{env_var.key}="how:are_you:$HOME/you:there:$#{env_var.key}"})
-
-    # Can write to layers for CNB interface
-    Dir.mktmpdir do |dir|
-      layers_dir = Pathname(dir)
-
-      env_var.write_layer(layers_dir: layers_dir)
-
-      expect(layers_dir.entries.map(&:to_s)).to include("foo")
-      expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.launch")
-      expect(layers_dir.join("foo").entries.map(&:to_s)).to include("env.build")
-
-      expect(layers_dir.join("foo/env.launch/#{env_var.key}").read).to eq("/hi/you:there")
-
-      env_var.write_layer(layers_dir: layers_dir)
-      expect(layers_dir.join("bar").entries.map(&:to_s)).to include("env.launch")
-      expect(layers_dir.join("bar").entries.map(&:to_s)).to include("env.build")
-
-      expect(layers_dir.join("bar/env.launch/#{env_var.key}").read).to eq("how:are_you")
-    end
-  ensure
-    HerokuBuildpackRuby::EnvProxy.delete(env_var) if env_var
   end
 end

--- a/spec/unit/metadata_spec.rb
+++ b/spec/unit/metadata_spec.rb
@@ -2,115 +2,117 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "metadata" do
-  describe "top level interface" do
-    it "works" do
-      Dir.mktmpdir do |dir|
-        dir = Pathname(dir)
-        metadata = HerokuBuildpackRuby::Metadata.new(dir: dir, type: HerokuBuildpackRuby::Metadata::CNB)
-        expect(metadata.layer(:ruby).class).to eq(HerokuBuildpackRuby::Metadata::CNB)
+module HerokuBuildpackRuby
+  RSpec.describe "metadata" do
+    describe "top level interface" do
+      it "works" do
+        Dir.mktmpdir do |dir|
+          dir = Pathname(dir)
+          metadata = Metadata.new(dir: dir, type: Metadata::CNB)
+          expect(metadata.layer(:ruby).class).to eq(Metadata::CNB)
 
-        metadata = HerokuBuildpackRuby::Metadata.new(dir: dir, type: HerokuBuildpackRuby::Metadata::V2)
-        expect(metadata.layer(:ruby).class).to eq(HerokuBuildpackRuby::Metadata::V2)
+          metadata = Metadata.new(dir: dir, type: Metadata::V2)
+          expect(metadata.layer(:ruby).class).to eq(Metadata::V2)
+        end
+      end
+
+      it "null can be created with no directory or type" do
+        null = Metadata::Null.new
+        null.layer(:ruby).set(version: "2.7.2")
+        expect(null.layer(:ruby).get(:version)).to eq("2.7.2")
       end
     end
 
-    it "null can be created with no directory or type" do
-      null = HerokuBuildpackRuby::Metadata::Null.new
-      null.layer(:ruby).set(version: "2.7.2")
-      expect(null.layer(:ruby).get(:version)).to eq("2.7.2")
-    end
-  end
+    describe "in memory Engine" do
+      it "works" do
+        Dir.mktmpdir do |dir|
+          dir = Pathname(dir)
+          engine = Metadata::InMemory.new(dir: dir, name: :ruby)
+          expect(engine.get(:foo)).to be_nil
+          engine.set(foo: "bar")
+          expect(engine.get(:foo)).to eq("bar")
 
-  describe "in memory Engine" do
-    it "works" do
-      Dir.mktmpdir do |dir|
-        dir = Pathname(dir)
-        engine = HerokuBuildpackRuby::Metadata::InMemory.new(dir: dir, name: :ruby)
-        expect(engine.get(:foo)).to be_nil
-        engine.set(foo: "bar")
-        expect(engine.get(:foo)).to eq("bar")
+          expect(engine.get(:lol)).to eq(nil)
+          out = engine.fetch(:lol) do
+            "haha"
+          end
+          expect(out).to eq("haha")
+          expect(engine.get(:lol)).to eq("haha")
 
-        expect(engine.get(:lol)).to eq(nil)
-        out = engine.fetch(:lol) do
-          "haha"
+          out = engine.fetch(:lol) do
+            "hehe"
+          end
+          expect(out).to eq("haha")
+          expect(engine.get(:lol)).to eq("haha")
         end
-        expect(out).to eq("haha")
-        expect(engine.get(:lol)).to eq("haha")
-
-        out = engine.fetch(:lol) do
-          "hehe"
-        end
-        expect(out).to eq("haha")
-        expect(engine.get(:lol)).to eq("haha")
       end
     end
-  end
 
-  describe "CNB Engine" do
-    it "works" do
-      Dir.mktmpdir do |dir|
-        dir = Pathname(dir)
-        engine = HerokuBuildpackRuby::Metadata::CNB.new(dir: dir, name: :ruby)
-        expect(engine.get(:foo)).to be_nil
-        engine.set(foo: "bar")
-        expect(engine.get(:foo)).to eq("bar")
+    describe "CNB Engine" do
+      it "works" do
+        Dir.mktmpdir do |dir|
+          dir = Pathname(dir)
+          engine = Metadata::CNB.new(dir: dir, name: :ruby)
+          expect(engine.get(:foo)).to be_nil
+          engine.set(foo: "bar")
+          expect(engine.get(:foo)).to eq("bar")
 
-        expect(engine.get(:lol)).to eq(nil)
-        out = engine.fetch(:lol) do
-          "haha"
+          expect(engine.get(:lol)).to eq(nil)
+          out = engine.fetch(:lol) do
+            "haha"
+          end
+          expect(out).to eq("haha")
+          expect(engine.get(:lol)).to eq("haha")
+
+          out = engine.fetch(:lol) do
+            "hehe"
+          end
+          expect(out).to eq("haha")
+          expect(engine.get(:lol)).to eq("haha")
+
+          hash = TOML.load(dir.join("ruby", "store.toml").read)
+          expect(hash).to eq({:metadata=>{:foo=>"bar", :lol=>"haha"}})
+
+
+          engine_2 = Metadata::CNB.new(dir: dir, name: :ruby)
+
+          expect(engine_2.to_h).to eq(engine.to_h)
         end
-        expect(out).to eq("haha")
-        expect(engine.get(:lol)).to eq("haha")
-
-        out = engine.fetch(:lol) do
-          "hehe"
-        end
-        expect(out).to eq("haha")
-        expect(engine.get(:lol)).to eq("haha")
-
-        hash = HerokuBuildpackRuby::TOML.load(dir.join("ruby", "store.toml").read)
-        expect(hash).to eq({:metadata=>{:foo=>"bar", :lol=>"haha"}})
-
-
-        engine_2 = HerokuBuildpackRuby::Metadata::CNB.new(dir: dir, name: :ruby)
-
-        expect(engine_2.to_h).to eq(engine.to_h)
       end
     end
-  end
 
-  describe "V2 Engine" do
-    it "works" do
-      Dir.mktmpdir do |dir|
-        dir = Pathname(dir)
-        engine = HerokuBuildpackRuby::Metadata::V2.new(dir: dir, name: :ruby)
-        expect(engine.get(:foo)).to be_nil
-        engine.set(foo: "bar")
-        expect(engine.get(:foo)).to eq("bar")
+    describe "V2 Engine" do
+      it "works" do
+        Dir.mktmpdir do |dir|
+          dir = Pathname(dir)
+          engine = Metadata::V2.new(dir: dir, name: :ruby)
+          expect(engine.get(:foo)).to be_nil
+          engine.set(foo: "bar")
+          expect(engine.get(:foo)).to eq("bar")
 
-        expect(engine.get(:lol)).to eq(nil)
-        out = engine.fetch(:lol) do
-          "haha"
+          expect(engine.get(:lol)).to eq(nil)
+          out = engine.fetch(:lol) do
+            "haha"
+          end
+          expect(out).to eq("haha")
+          expect(engine.get(:lol)).to eq("haha")
+
+          out = engine.fetch(:lol) do
+            "hehe"
+          end
+          expect(out).to eq("haha")
+          expect(engine.get(:lol)).to eq("haha")
+
+          expect(dir.join("ruby").entries.map(&:to_s)).to include("lol")
+          expect(dir.join("ruby").entries.map(&:to_s)).to include("foo")
+
+          expect(dir.join("ruby", "foo").read).to eq("bar")
+          expect(dir.join("ruby", "lol").read).to eq("haha")
+
+
+          engine_2 = Metadata::V2.new(dir: dir, name: :ruby)
+          expect(engine_2.to_h).to eq(engine.to_h)
         end
-        expect(out).to eq("haha")
-        expect(engine.get(:lol)).to eq("haha")
-
-        out = engine.fetch(:lol) do
-          "hehe"
-        end
-        expect(out).to eq("haha")
-        expect(engine.get(:lol)).to eq("haha")
-
-        expect(dir.join("ruby").entries.map(&:to_s)).to include("lol")
-        expect(dir.join("ruby").entries.map(&:to_s)).to include("foo")
-
-        expect(dir.join("ruby", "foo").read).to eq("bar")
-        expect(dir.join("ruby", "lol").read).to eq("haha")
-
-
-        engine_2 = HerokuBuildpackRuby::Metadata::V2.new(dir: dir, name: :ruby)
-        expect(engine_2.to_h).to eq(engine.to_h)
       end
     end
   end

--- a/spec/unit/prepare_app_bundler_and_ruby_spec.rb
+++ b/spec/unit/prepare_app_bundler_and_ruby_spec.rb
@@ -2,116 +2,118 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "PrepareAppBundlerAndRuby" do
-  describe "interfaces get called" do
-    it "integration" do
-      Dir.mktmpdir do |app_dir|
-        Dir.mktmpdir do |vendor_dir|
-          isolate_in_fork do
-            app_dir = Pathname(app_dir)
-            vendor_dir = Pathname(vendor_dir)
+module HerokuBuildpackRuby
+  RSpec.describe "PrepareAppBundlerAndRuby" do
+    describe "interfaces get called" do
+      it "integration" do
+        Dir.mktmpdir do |app_dir|
+          Dir.mktmpdir do |vendor_dir|
+            isolate_in_fork do
+              app_dir = Pathname(app_dir)
+              vendor_dir = Pathname(vendor_dir)
 
-            gemfile = Pathname(app_dir).join("Gemfile")
+              gemfile = Pathname(app_dir).join("Gemfile")
 
-            gemfile.write("")
+              gemfile.write("")
 
-            lockfile = Pathname(app_dir).join("Gemfile.lock")
-            lockfile.write <<~EOM
-              RUBY VERSION
-                 ruby 2.7.2p146
-            EOM
+              lockfile = Pathname(app_dir).join("Gemfile.lock")
+              lockfile.write <<~EOM
+                RUBY VERSION
+                   ruby 2.7.2p146
+              EOM
 
-            user_comms = HerokuBuildpackRuby::UserComms::Null.new
-            bootstrap = HerokuBuildpackRuby::PrepareAppBundlerAndRuby.new(
-              buildpack_ruby_path: which_ruby,
-              bundler_install_dir: vendor_dir.join("bundler"),
-              ruby_install_dir: vendor_dir.join("ruby"),
-              user_comms: user_comms,
-              app_dir: app_dir,
-              stack: "heroku-18"
-            )
+              user_comms = UserComms::Null.new
+              bootstrap = PrepareAppBundlerAndRuby.new(
+                buildpack_ruby_path: which_ruby,
+                bundler_install_dir: vendor_dir.join("bundler"),
+                ruby_install_dir: vendor_dir.join("ruby"),
+                user_comms: user_comms,
+                app_dir: app_dir,
+                stack: "heroku-18"
+              )
 
-            bootstrap.call
+              bootstrap.call
 
-            output = user_comms.close.to_string
-            expect(output).to include("Installing bundler")
-            expect(output).to include("Removing BUNDLED WITH from Gemfile.lock")
-            expect(output).to include("Using Ruby version: 2.7.2")
+              output = user_comms.close.to_string
+              expect(output).to include("Installing bundler")
+              expect(output).to include("Removing BUNDLED WITH from Gemfile.lock")
+              expect(output).to include("Using Ruby version: 2.7.2")
 
-            expect(ENV["PATH"]).to include(vendor_dir.join("ruby").to_s)
-            expect(ENV["PATH"]).to include(vendor_dir.join("bundler/bin").to_s)
-            expect(ENV["GEM_PATH"]).to include(vendor_dir.join("bundler").to_s)
+              expect(ENV["PATH"]).to include(vendor_dir.join("ruby").to_s)
+              expect(ENV["PATH"]).to include(vendor_dir.join("bundler/bin").to_s)
+              expect(ENV["GEM_PATH"]).to include(vendor_dir.join("bundler").to_s)
+            end
           end
         end
       end
     end
-  end
 
-  describe "ruby" do
-    it "detects version" do
-      Dir.mktmpdir do |dir|
-        lockfile = Pathname(dir).join("Gemfile.lock")
-        lockfile.write <<~EOM
-          RUBY VERSION
-             ruby 2.6.23p146
-        EOM
+    describe "ruby" do
+      it "detects version" do
+        Dir.mktmpdir do |dir|
+          lockfile = Pathname(dir).join("Gemfile.lock")
+          lockfile.write <<~EOM
+            RUBY VERSION
+               ruby 2.6.23p146
+          EOM
 
-        vendor_dir = Pathname(dir).join(".heroku/")
-        bootstrap = HerokuBuildpackRuby::PrepareAppBundlerAndRuby.new(
-          buildpack_ruby_path: which_ruby,
-          bundler_install_dir: vendor_dir.join("bundler"),
-          ruby_install_dir: vendor_dir.join("ruby"),
-          app_dir: dir,
-        )
-        ruby_version = bootstrap.ruby_detect_version
-
-        expect(ruby_version).to eq("2.6.23")
-      end
-    end
-  end
-
-  describe "bundler" do
-    it "detects major bundler version" do
-      Dir.mktmpdir do |dir|
-        lockfile = Pathname(dir).join("Gemfile.lock")
-        lockfile.write <<~EOM
-          BUNDLED WITH
-             2.1.4
-        EOM
-
-        vendor_dir = Pathname(dir).join(".heroku/")
-        bootstrap = HerokuBuildpackRuby::PrepareAppBundlerAndRuby.new(
-          buildpack_ruby_path: which_ruby,
-          bundler_install_dir: vendor_dir.join("bundler"),
-          ruby_install_dir: vendor_dir.join("ruby"),
-          app_dir: dir,
-        )
-        bundler_version = bootstrap.bundler_detect_version
-
-        expect(bundler_version).to eq(HerokuBuildpackRuby::BundlerDetectVersion::BUNDLER_VERSIONS["2"])
-      end
-    end
-
-    it "downloads bundler" do
-      Dir.mktmpdir do |bundler_dest_dir|
-        bundler_dest_dir = Pathname(bundler_dest_dir)
-        Dir.mktmpdir do |app_dir|
-          app_dir = Pathname(app_dir)
-          app_dir.join("Gemfile.lock").tap {|p| FileUtils.touch(p) }
-
-          vendor_dir = app_dir.join(".heroku/")
-          bootstrap = HerokuBuildpackRuby::PrepareAppBundlerAndRuby.new(
+          vendor_dir = Pathname(dir).join(".heroku/")
+          bootstrap = PrepareAppBundlerAndRuby.new(
             buildpack_ruby_path: which_ruby,
-            bundler_install_dir: bundler_dest_dir,
+            bundler_install_dir: vendor_dir.join("bundler"),
             ruby_install_dir: vendor_dir.join("ruby"),
-            app_dir: app_dir,
+            app_dir: dir,
           )
+          ruby_version = bootstrap.ruby_detect_version
 
-          bootstrap.bundler_detect_version
-          bootstrap.bundler_download_version
+          expect(ruby_version).to eq("2.6.23")
+        end
+      end
+    end
 
-          expect(bundler_dest_dir.entries.map(&:to_s)).to include("bin")
-          expect(bundler_dest_dir.entries.map(&:to_s)).to include("gems")
+    describe "bundler" do
+      it "detects major bundler version" do
+        Dir.mktmpdir do |dir|
+          lockfile = Pathname(dir).join("Gemfile.lock")
+          lockfile.write <<~EOM
+            BUNDLED WITH
+               2.1.4
+          EOM
+
+          vendor_dir = Pathname(dir).join(".heroku/")
+          bootstrap = PrepareAppBundlerAndRuby.new(
+            buildpack_ruby_path: which_ruby,
+            bundler_install_dir: vendor_dir.join("bundler"),
+            ruby_install_dir: vendor_dir.join("ruby"),
+            app_dir: dir,
+          )
+          bundler_version = bootstrap.bundler_detect_version
+
+          expect(bundler_version).to eq(BundlerDetectVersion::BUNDLER_VERSIONS["2"])
+        end
+      end
+
+      it "downloads bundler" do
+        Dir.mktmpdir do |bundler_dest_dir|
+          bundler_dest_dir = Pathname(bundler_dest_dir)
+          Dir.mktmpdir do |app_dir|
+            app_dir = Pathname(app_dir)
+            app_dir.join("Gemfile.lock").tap {|p| FileUtils.touch(p) }
+
+            vendor_dir = app_dir.join(".heroku/")
+            bootstrap = PrepareAppBundlerAndRuby.new(
+              buildpack_ruby_path: which_ruby,
+              bundler_install_dir: bundler_dest_dir,
+              ruby_install_dir: vendor_dir.join("ruby"),
+              app_dir: app_dir,
+            )
+
+            bootstrap.bundler_detect_version
+            bootstrap.bundler_download_version
+
+            expect(bundler_dest_dir.entries.map(&:to_s)).to include("bin")
+            expect(bundler_dest_dir.entries.map(&:to_s)).to include("gems")
+          end
         end
       end
     end

--- a/spec/unit/rake_detect_spec.rb
+++ b/spec/unit/rake_detect_spec.rb
@@ -3,133 +3,135 @@
 require_relative "../spec_helper.rb"
 
 
-RSpec.describe "rake detect" do
-  describe "failures and warnings" do
-    it "detects when there is no rake gem" do
-      Hatchet::Runner.new("default_ruby").in_directory do
-        app_dir = Pathname(Dir.pwd)
-        app_dir.join("Rakefile").delete
+module HerokuBuildpackRuby
+  RSpec.describe "rake detect" do
+    describe "failures and warnings" do
+      it "detects when there is no rake gem" do
+        Hatchet::Runner.new("default_ruby").in_directory do
+          app_dir = Pathname(Dir.pwd)
+          app_dir.join("Rakefile").delete
 
-        Bundler.with_original_env do
-          user_comms = HerokuBuildpackRuby::UserComms::Null.new
-          rake = HerokuBuildpackRuby::RakeDetect.new(
-            app_dir: app_dir,
-            user_comms: user_comms,
-            has_rake_gem: false
-          ).call
-
-          expect(user_comms.to_string).to include("No `rake` gem")
-          expect(rake.loaded?).to be_falsey
-          expect(rake.detect?("assets:precompile")).to be_falsey
-
-          expect {
-            rake = HerokuBuildpackRuby::RakeDetect.new(
+          Bundler.with_original_env do
+            user_comms = UserComms::Null.new
+            rake = RakeDetect.new(
               app_dir: app_dir,
-              has_rake_gem: false,
-              error_if_detect_fails: true
+              user_comms: user_comms,
+              has_rake_gem: false
             ).call
-          }.to raise_error(/No `rake` gem/)
+
+            expect(user_comms.to_string).to include("No `rake` gem")
+            expect(rake.loaded?).to be_falsey
+            expect(rake.detect?("assets:precompile")).to be_falsey
+
+            expect {
+              rake = RakeDetect.new(
+                app_dir: app_dir,
+                has_rake_gem: false,
+                error_if_detect_fails: true
+              ).call
+            }.to raise_error(/No `rake` gem/)
+          end
+        end
+      end
+
+      it "detects when there is no Rakefile" do
+
+        Hatchet::Runner.new("default_ruby").in_directory do
+          app_dir = Pathname(Dir.pwd)
+          app_dir.join("Rakefile").delete
+
+          Bundler.with_original_env do
+            user_comms = UserComms::Null.new
+            rake = RakeDetect.new(
+              app_dir: app_dir,
+              user_comms: user_comms,
+              has_rake_gem: true
+            ).call
+
+            expect(user_comms.to_string).to include("No Rakefile found")
+            expect(rake.loaded?).to be_falsey
+            expect(rake.detect?("assets:precompile")).to be_falsey
+
+            expect {
+              rake = RakeDetect.new(
+                app_dir: app_dir,
+                has_rake_gem: true,
+                error_if_detect_fails: true
+              ).call
+            }.to raise_error(/No Rakefile found/)
+          end
+        end
+      end
+
+      it "detects when there is an exception in the Rakefile" do
+        Hatchet::Runner.new("default_ruby").in_directory do
+          app_dir = Pathname(Dir.pwd)
+          app_dir.join("Rakefile").write <<~EOM
+            raise "nope"
+          EOM
+
+          Bundler.with_original_env do
+            user_comms = UserComms::Null.new
+            rake = RakeDetect.new(
+              app_dir: app_dir,
+              user_comms: user_comms,
+              has_rake_gem: true
+            ).call
+
+            expect(user_comms.to_string).to include("Rake task detection failed")
+            expect(rake.loaded?).to be_falsey
+            expect(rake.detect?("assets:precompile")).to be_falsey
+
+            expect {
+              rake = RakeDetect.new(
+                app_dir: app_dir,
+                has_rake_gem: true,
+                error_if_detect_fails: true
+              ).call
+            }.to raise_error(/Rake task detection failed/)
+          end
         end
       end
     end
 
-    it "detects when there is no Rakefile" do
 
-      Hatchet::Runner.new("default_ruby").in_directory do
-        app_dir = Pathname(Dir.pwd)
-        app_dir.join("Rakefile").delete
-
-        Bundler.with_original_env do
-          user_comms = HerokuBuildpackRuby::UserComms::Null.new
-          rake = HerokuBuildpackRuby::RakeDetect.new(
-            app_dir: app_dir,
-            user_comms: user_comms,
-            has_rake_gem: true
-          ).call
-
-          expect(user_comms.to_string).to include("No Rakefile found")
-          expect(rake.loaded?).to be_falsey
-          expect(rake.detect?("assets:precompile")).to be_falsey
-
-          expect {
-            rake = HerokuBuildpackRuby::RakeDetect.new(
-              app_dir: app_dir,
-              has_rake_gem: true,
-              error_if_detect_fails: true
-            ).call
-          }.to raise_error(/No Rakefile found/)
-        end
-      end
-    end
-
-    it "detects when there is an exception in the Rakefile" do
+    it "detects when assets:precompile is not present" do
       Hatchet::Runner.new("default_ruby").in_directory do
         app_dir = Pathname(Dir.pwd)
         app_dir.join("Rakefile").write <<~EOM
-          raise "nope"
+         # Empty
         EOM
 
         Bundler.with_original_env do
-          user_comms = HerokuBuildpackRuby::UserComms::Null.new
-          rake = HerokuBuildpackRuby::RakeDetect.new(
+          rake = RakeDetect.new(
             app_dir: app_dir,
-            user_comms: user_comms,
             has_rake_gem: true
           ).call
 
-          expect(user_comms.to_string).to include("Rake task detection failed")
-          expect(rake.loaded?).to be_falsey
+          expect(rake.loaded?).to be_truthy
           expect(rake.detect?("assets:precompile")).to be_falsey
-
-          expect {
-            rake = HerokuBuildpackRuby::RakeDetect.new(
-              app_dir: app_dir,
-              has_rake_gem: true,
-              error_if_detect_fails: true
-            ).call
-          }.to raise_error(/Rake task detection failed/)
         end
       end
     end
-  end
 
+    it "detects asset tasks when they exist" do
+      Hatchet::Runner.new("default_ruby").in_directory do
+        app_dir = Pathname(Dir.pwd)
+        app_dir.join("Rakefile").write <<~EOM
+          task "assets:precompile" do
+            puts "success!"
+          end
+        EOM
 
-  it "detects when assets:precompile is not present" do
-    Hatchet::Runner.new("default_ruby").in_directory do
-      app_dir = Pathname(Dir.pwd)
-      app_dir.join("Rakefile").write <<~EOM
-       # Empty
-      EOM
+        Bundler.with_original_env do
+          rake = RakeDetect.new(
+            app_dir: app_dir,
+            has_rake_gem: true
+          ).call
 
-      Bundler.with_original_env do
-        rake = HerokuBuildpackRuby::RakeDetect.new(
-          app_dir: app_dir,
-          has_rake_gem: true
-        ).call
-
-        expect(rake.loaded?).to be_truthy
-        expect(rake.detect?("assets:precompile")).to be_falsey
-      end
-    end
-  end
-
-  it "detects asset tasks when they exist" do
-    Hatchet::Runner.new("default_ruby").in_directory do
-      app_dir = Pathname(Dir.pwd)
-      app_dir.join("Rakefile").write <<~EOM
-        task "assets:precompile" do
-          puts "success!"
+          expect(rake.loaded?).to be_truthy
+          expect(rake.detect?("assets:precompile")).to be_truthy
         end
-      EOM
-
-      Bundler.with_original_env do
-        rake = HerokuBuildpackRuby::RakeDetect.new(
-          app_dir: app_dir,
-          has_rake_gem: true
-        ).call
-
-        expect(rake.loaded?).to be_truthy
-        expect(rake.detect?("assets:precompile")).to be_truthy
       end
     end
   end

--- a/spec/unit/ruby_detect_version_spec.rb
+++ b/spec/unit/ruby_detect_version_spec.rb
@@ -2,116 +2,118 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "detect ruby version" do
-  it "matches on lockfile" do
-    Dir.mktmpdir do |dir|
-      lockfile = Pathname(dir).join("Gemfile.lock")
-      lockfile.write <<~EOM
-        PLATFORMS
-          ruby
+module HerokuBuildpackRuby
+  RSpec.describe "detect ruby version" do
+    it "matches on lockfile" do
+      Dir.mktmpdir do |dir|
+        lockfile = Pathname(dir).join("Gemfile.lock")
+        lockfile.write <<~EOM
+          PLATFORMS
+            ruby
 
-        DEPENDENCIES
-          heroku_hatchet
-          parallel_split_test
-          rspec-retry
+          DEPENDENCIES
+            heroku_hatchet
+            parallel_split_test
+            rspec-retry
 
-        RUBY VERSION
-           ruby 2.7.2p137
+          RUBY VERSION
+             ruby 2.7.2p137
 
-        BUNDLED WITH
-           2.1.4
-      EOM
-      ruby_version = HerokuBuildpackRuby::RubyDetectVersion.new(
-        buildpack_ruby_path: which_ruby,
-        bundler_path: which_bundle,
-        gemfile_dir: dir
-      )
-      ruby_version.call
-      expect(ruby_version.version).to eq("2.7.2")
-    end
-  end
-
-  it "detects from Gemfile" do
-    Dir.mktmpdir do |dir|
-
-      File.open("#{dir}/Gemfile", "w+") do |f|
-        f.write "ruby '2.7.6'"
-      end
-      FileUtils.touch("#{dir}/Gemfile.lock")
-
-      ruby_version = HerokuBuildpackRuby::RubyDetectVersion.new(
-        buildpack_ruby_path: which_ruby,
-        bundler_path: which_bundle,
-        gemfile_dir: dir
-      )
-
-      # We need a clean environment, we don't want to run bundler inside of another bundler
-      Bundler.with_unbundled_env do
+          BUNDLED WITH
+             2.1.4
+        EOM
+        ruby_version = RubyDetectVersion.new(
+          buildpack_ruby_path: which_ruby,
+          bundler_path: which_bundle,
+          gemfile_dir: dir
+        )
         ruby_version.call
-        expect(ruby_version.version).to eq("2.7.6")
+        expect(ruby_version.version).to eq("2.7.2")
       end
     end
-  end
 
-  it "defaults if empty" do
-    Dir.mktmpdir do |dir|
+    it "detects from Gemfile" do
+      Dir.mktmpdir do |dir|
 
-      FileUtils.touch("#{dir}/Gemfile.lock")
-      FileUtils.touch("#{dir}/Gemfile")
+        File.open("#{dir}/Gemfile", "w+") do |f|
+          f.write "ruby '2.7.6'"
+        end
+        FileUtils.touch("#{dir}/Gemfile.lock")
 
-      user_comms = HerokuBuildpackRuby::UserComms::Null.new
-      ruby_version = HerokuBuildpackRuby::RubyDetectVersion.new(
-        user_comms: user_comms,
-        gemfile_dir: dir,
-        bundler_path: which_bundle,
-        buildpack_ruby_path: which_ruby,
-      )
+        ruby_version = RubyDetectVersion.new(
+          buildpack_ruby_path: which_ruby,
+          bundler_path: which_bundle,
+          gemfile_dir: dir
+        )
 
-      # We need a clean environment, we don't want to run bundler inside of another bundler
-      Bundler.with_unbundled_env do
-        ruby_version.call
-        expect(ruby_version.version).to eq(HerokuBuildpackRuby::RubyDetectVersion::DEFAULT)
+        # We need a clean environment, we don't want to run bundler inside of another bundler
+        Bundler.with_unbundled_env do
+          ruby_version.call
+          expect(ruby_version.version).to eq("2.7.6")
+        end
       end
-
-      user_comms.close
-      expect(user_comms.io.string).to include("You have not declared a Ruby version in your Gemfile")
     end
-  end
 
-  it "has a sticky default" do
-    Dir.mktmpdir do |dir|
+    it "defaults if empty" do
+      Dir.mktmpdir do |dir|
 
-      FileUtils.touch("#{dir}/Gemfile.lock")
-      FileUtils.touch("#{dir}/Gemfile")
+        FileUtils.touch("#{dir}/Gemfile.lock")
+        FileUtils.touch("#{dir}/Gemfile")
 
-      metadata = HerokuBuildpackRuby::Metadata::Null.new
-      ruby_version = HerokuBuildpackRuby::RubyDetectVersion.new(
-        metadata: metadata,
-        gemfile_dir: dir,
-        bundler_path: which_bundle,
-        default_version: "2.7.1",
-        buildpack_ruby_path: which_ruby,
-      )
+        user_comms = UserComms::Null.new
+        ruby_version = RubyDetectVersion.new(
+          user_comms: user_comms,
+          gemfile_dir: dir,
+          bundler_path: which_bundle,
+          buildpack_ruby_path: which_ruby,
+        )
 
-      # We need a clean environment, we don't want to run bundler inside of another bundler
-      Bundler.with_unbundled_env do
-        ruby_version.call
-        expect(ruby_version.version).to eq("2.7.1")
-        expect(metadata.layer(:ruby).get(:default_version)).to eq("2.7.1")
+        # We need a clean environment, we don't want to run bundler inside of another bundler
+        Bundler.with_unbundled_env do
+          ruby_version.call
+          expect(ruby_version.version).to eq(RubyDetectVersion::DEFAULT)
+        end
+
+        user_comms.close
+        expect(user_comms.io.string).to include("You have not declared a Ruby version in your Gemfile")
       end
+    end
 
-      # It should be stickey
-      ruby_version = HerokuBuildpackRuby::RubyDetectVersion.new(
-        metadata: metadata,
-        gemfile_dir: dir,
-        bundler_path: which_bundle,
-        default_version: "2.2.2",
-        buildpack_ruby_path: which_ruby,
-      )
+    it "has a sticky default" do
+      Dir.mktmpdir do |dir|
 
-      Bundler.with_unbundled_env do
-        ruby_version.call
-        expect(ruby_version.version).to eq("2.7.1")
+        FileUtils.touch("#{dir}/Gemfile.lock")
+        FileUtils.touch("#{dir}/Gemfile")
+
+        metadata = Metadata::Null.new
+        ruby_version = RubyDetectVersion.new(
+          metadata: metadata,
+          gemfile_dir: dir,
+          bundler_path: which_bundle,
+          default_version: "2.7.1",
+          buildpack_ruby_path: which_ruby,
+        )
+
+        # We need a clean environment, we don't want to run bundler inside of another bundler
+        Bundler.with_unbundled_env do
+          ruby_version.call
+          expect(ruby_version.version).to eq("2.7.1")
+          expect(metadata.layer(:ruby).get(:default_version)).to eq("2.7.1")
+        end
+
+        # It should be stickey
+        ruby_version = RubyDetectVersion.new(
+          metadata: metadata,
+          gemfile_dir: dir,
+          bundler_path: which_bundle,
+          default_version: "2.2.2",
+          buildpack_ruby_path: which_ruby,
+        )
+
+        Bundler.with_unbundled_env do
+          ruby_version.call
+          expect(ruby_version.version).to eq("2.7.1")
+        end
       end
     end
   end

--- a/spec/unit/ruby_download_spec.rb
+++ b/spec/unit/ruby_download_spec.rb
@@ -2,20 +2,22 @@
 
 require_relative "../spec_helper.rb"
 
-RSpec.describe "download ruby" do
-  it "downloads a ruby" do
-    Dir.mktmpdir do |dir|
-      HerokuBuildpackRuby::RubyDownload.new(
-        version: "2.7.2",
-        stack: "heroku-18",
-        install_dir: dir
-      ).call
+module HerokuBuildpackRuby
+  RSpec.describe "download ruby" do
+    it "downloads a ruby" do
+      Dir.mktmpdir do |dir|
+        RubyDownload.new(
+          version: "2.7.2",
+          stack: "heroku-18",
+          install_dir: dir
+        ).call
 
-      entries = Dir.entries(dir) - [".", ".."]
-      expect(entries).to include("bin")
-      expect(entries).to include("include")
-      expect(entries).to include("lib")
-      expect(entries).to include("share")
+        entries = Dir.entries(dir) - [".", ".."]
+        expect(entries).to include("bin")
+        expect(entries).to include("include")
+        expect(entries).to include("lib")
+        expect(entries).to include("share")
+      end
     end
   end
 end

--- a/spec/unit/toml_spec.rb
+++ b/spec/unit/toml_spec.rb
@@ -2,17 +2,18 @@
 
 require_relative "../spec_helper.rb"
 
+module HerokuBuildpackRuby
+  RSpec.describe "toml" do
+    it "parses toml correctly" do
+      toml = <<~EOM
+        [[provides]]
+        name = "hello"
+        [[provides]]
+        name = "there"
+      EOM
 
-RSpec.describe "toml" do
-  it "parses toml correctly" do
-    toml = <<~EOM
-      [[provides]]
-      name = "hello"
-      [[provides]]
-      name = "there"
-    EOM
-
-    actual = HerokuBuildpackRuby::TOML.load(toml)
-    expect(actual).to eq({provides: [{name: "hello"}, {name: "there"}]})
+      actual = HerokuBuildpackRuby::TOML.load(toml)
+      expect(actual).to eq({provides: [{name: "hello"}, {name: "there"}]})
+    end
   end
 end


### PR DESCRIPTION
By having all our specs in the namespace it allows us to reference constants without having to use the fully qualified `HerokuBuildpackRuby::` EVERY time.

This change wraps all spec definitions in a `module HerokuBuildpackRuby` block, adds indentation, and removes fully qualified constants in favor of their short equivalents.