### PR TITLE
[changelog skip] CNB logging style

### DIFF
--- a/lib/heroku_buildpack_ruby.rb
+++ b/lib/heroku_buildpack_ruby.rb
@@ -22,7 +22,15 @@ require_relative "heroku_buildpack_ruby/assets_precompile.rb"
 #   HerokuBuildpackRuby.build_cnb(...)
 #
 module HerokuBuildpackRuby
-  class BuildpackErrorNoBacktrace < StandardError; end
+  class BuildpackErrorNoBacktrace < StandardError
+    attr_reader :title, :body, :link
+    def initialize(title: , body:, link: nil)
+      @title = title
+      @body = body
+      @link = link
+      super [title, body, link].join("\n")
+    end
+  end
 
   BUILDPACK_DIR = Pathname(__dir__).join("..")
   EnvProxy.register_layer(:gems,    build: true, cache: true,  launch: true)
@@ -96,7 +104,8 @@ module HerokuBuildpackRuby
       )
       user_comms.close
     rescue BuildpackErrorNoBacktrace => e
-      user_comms.error_and_exit(e.message)
+      user_comms.print_error_obj(e)
+      exit(1)
     end
   end
 
@@ -157,7 +166,8 @@ module HerokuBuildpackRuby
       user_comms.close
 
     rescue BuildpackErrorNoBacktrace => e
-      user_comms.error_and_exit(e.message)
+      user_comms.print_error_obj(e)
+      exit(1)
     end
   end
 end

--- a/lib/heroku_buildpack_ruby/assets_precompile.rb
+++ b/lib/heroku_buildpack_ruby/assets_precompile.rb
@@ -34,7 +34,7 @@ module HerokuBuildpackRuby
     end
 
     private def warn_assets_precompiled_maniefest
-      @user_comms.puts("Skipping `rake assets:precompile`: Precompiled asset manifest found: #{assets_manifest}")
+      @user_comms.info("Skipping `rake assets:precompile`: Precompiled asset manifest found: #{assets_manifest}")
     end
 
     private def assets_precompile
@@ -42,7 +42,7 @@ module HerokuBuildpackRuby
         @user_comms.topic("Running: rake assets:precompile")
         RakeTask.new("assets:precompile", stream: @user_comms).call
       else
-        @user_comms.puts("Asset compilation skipped: `rake assets:precompile` not found")
+        @user_comms.info("Asset compilation skipped: `rake assets:precompile` not found")
       end
     end
 
@@ -52,7 +52,7 @@ module HerokuBuildpackRuby
 
         RakeTask.new("assets:clean", stream: @user_comms).call
       else
-        @user_comms.puts("Asset clean skipped: `rake assets:clean` not found")
+        @user_comms.info("Asset clean skipped: `rake assets:clean` not found")
       end
     end
 

--- a/lib/heroku_buildpack_ruby/rake_detect.rb
+++ b/lib/heroku_buildpack_ruby/rake_detect.rb
@@ -39,37 +39,44 @@ module HerokuBuildpackRuby
     end
 
     private def warn_no_rake_gem
-      warn_or_error("No `rake` gem in the Gemfile.lock, skipping rake detection")
+      warn_or_error(
+        title: "No rake gem",
+        body: "No `rake` gem in the Gemfile.lock, skipping rake detection"
+      )
     end
 
     private def warn_no_rakefile
-      warn_or_error <<~EOM
-        No Rakefile found in app directory, skipping rake detection
+      warn_or_error(
+        title: "No Rakefile found",
+        body: <<~EOM
+          No Rakefile found in app directory, skipping rake detection
 
-        Expected: #{RAKEFILE_NAMES.join(', ')}
-        Found: #{@app_dir.entries.select(&:file?).join(', ')}
-      EOM
+          Expected: #{RAKEFILE_NAMES.join(', ')}
+          Found: #{@app_dir.entries.select(&:file?).join(', ')}
+        EOM
+      )
     end
 
     private def detection_failed
       command = String.new("bundle exec rake -P")
       command.prepend("RAILS_ENV=#{ENV['RAILS_ENV']} ") if ENV.key?("RAILS_ENV")
 
-      warn_or_error <<~EOM
-        Rake task detection failed
+      warn_or_error(
+        title: "Rake task detection failed",
+        body: <<~EOM
+          Ensure you can run `$ #{command}` against your app
+          using the production group of your Gemfile.
 
-        Ensure you can run `$ #{command}` against your app
-        using the production group of your Gemfile.
-
-        #{@detect_task.out}
-      EOM
+          #{@detect_task.out}
+        EOM
+      )
     end
 
-    private def warn_or_error(message)
+    private def warn_or_error(title:, body:)
       if error_if_detect_fails
-        raise BuildpackErrorNoBacktrace, message
+        @user_comms.error(title: title, body: body)
       else
-        @user_comms.warn_now(message)
+        @user_comms.warn_now(title: title, body: body)
       end
     end
 

--- a/lib/heroku_buildpack_ruby/rake_task.rb
+++ b/lib/heroku_buildpack_ruby/rake_task.rb
@@ -15,7 +15,7 @@ module HerokuBuildpackRuby
 
     def initialize(task, stream: nil)
       @bash_task = Bash.new("rake #{task}")
-      @stream = stream || StringIO.new
+      @stream = stream || UserComms::Null.new
       @called = false
       @status = nil
       @out = String.new
@@ -26,7 +26,7 @@ module HerokuBuildpackRuby
 
       @bash_task.stream do |lines|
         @out << lines
-        @stream.puts lines
+        @stream.info lines
       end
       @status = $?.success?
 

--- a/lib/heroku_buildpack_ruby/ruby_detect_version.rb
+++ b/lib/heroku_buildpack_ruby/ruby_detect_version.rb
@@ -92,20 +92,19 @@ module HerokuBuildpackRuby
     end
 
     private def warn_default_ruby
-      warning = <<~WARNING
-        You have not declared a Ruby version in your Gemfile.
+      user_comms.warn_later(
+        title: "No declared Ruby version",
+        link: "https://devcenter.heroku.com/articles/ruby-versions",
+        body: <<~WARNING
+          You have not declared a Ruby version in your Gemfile.
 
-        To declare a Ruby version add this line to your Gemfile:
+          To declare a Ruby version add this line to your Gemfile:
 
-        ```
-        ruby "#{default_version}"
-        ```
-
-        For more information see:
-          https://devcenter.heroku.com/articles/ruby-versions
-      WARNING
-
-      user_comms.warn_later(warning)
+          ```
+          ruby "#{default_version}"
+          ```
+        WARNING
+      )
     end
   end
 end

--- a/lib/heroku_buildpack_ruby/ruby_download.rb
+++ b/lib/heroku_buildpack_ruby/ruby_download.rb
@@ -18,7 +18,7 @@ module HerokuBuildpackRuby
     end
 
     def call
-      user_comms.topic("Using Ruby version: #{version}")
+      user_comms.info("Using Ruby version: #{version}")
 
       CurlFetch.new(
         "ruby-#{version}.tgz",

--- a/lib/heroku_buildpack_ruby/user_comms.rb
+++ b/lib/heroku_buildpack_ruby/user_comms.rb
@@ -2,16 +2,8 @@
 
 module HerokuBuildpackRuby
   class UserComms; end
-  # This class is used to format output for the user targeted at v2/legacy (bin/compile) mode
-  #
-  # Example:
-  #
-  #   stringio = StringIO.new
-  #   user_output = UserOutput::V2.new(stringio)
-  #   user_output.topic("hello there")
-  #
-  #   puts stringio.string # => "-----> hello there\n"
-  class UserComms::V2
+
+  class UserComms::Base
     attr_reader :io
 
     def initialize(io = $stdout)
@@ -21,52 +13,124 @@ module HerokuBuildpackRuby
       @warnings = []
     end
 
-    def topic(message)
-      io.puts "-----> #{message}"
-    end
-
     def close
-      @warnings.each do |message|
-        warn_now(message)
+      @warnings.each do |kwargs|
+        warn_now(**kwargs)
       end
       self
     end
 
-    def warn_later(message)
-      @warnings << message
+    def warn_later(title: , body:, link: nil)
+      @warnings << {title: title, body: body, link: link}
     end
 
-    def warn_now(message)
-      self.puts
-      self.puts "## Warning"
-      self.puts
-      self.puts(message)
-      self.puts
+    def error(title: , body: , link: nil)
+      raise BuildpackErrorNoBacktrace.new(title: title, body: body, link: link)
+    end
+  end
+
+  # This class is used to format output for the user targeted at v2/legacy (bin/compile) mode
+  #
+  # Example:
+  #
+  #   stringio = StringIO.new
+  #   user_output = UserOutput::V2.new(stringio)
+  #   user_output.topic("hello there")
+  #
+  #   puts stringio.string # => "-----> hello there\n"
+  class UserComms::V2 < UserComms::Base
+    def topic(message) # status
+      io.puts "-----> #{message}"
     end
 
-    def error_and_exit(message)
-      self.puts "\e[1m\e[31m" # Bold Red
-      self.puts " !"
-      message.split("\n").each do |line|
-        io.puts " !     #{line.strip}"
-      end
-      self.puts " !\e[0m"
-      exit(1)
-    end
-
-    def puts(message = "")
+    def info(message = "\n")
       message.to_s.each_line do |line|
-        if line.end_with?("\n".freeze)
-          io.print "       #{line}"
-        else
-          io.print "       #{line}\n"
-        end
+        string = +""
+        string << "       #{line}" unless line.strip.empty?
+        string << "\n" unless string.end_with?("\n")
+        io.print string
       end
+    end
+
+    def warn_now(title:, body: , link: nil)
+      banner "Warning: #{title}"
+      info
+      info(body)
+      return unless link
+      info
+      info("Link: #{link}")
+    end
+
+    def notice(message)
+      banner "Notice: #{message}", color: "\033[1;38;2;64;143;236m"
+    end
+
+    def print_error_obj(error_obj)
+      title = error_obj.title
+      body = error_obj.body
+      link = error_obj.link
+      color = "\e[1m\e[31m" # bold red
+      no_color = "\033[0m"
+
+      banner "Error: #{title}", color: "\033[1;38;2;0;0;0;48;2;214;65;65m"
+
+      info
+      info   "#{color}!#{no_color}"
+      body.split("\n").each do |line|
+        info "#{color}!  #{line.strip}#{no_color}"
+      end
+      info   "#{color}! Link: #{link}#{no_color}" if link
+      info   "#{color}!#{no_color}"
+    end
+
+    private def banner(message, color: "", no_color: "\033[0m")
+      io.puts
+      io.puts("       #{color}## #{message.strip}#{no_color}")
     end
   end
 
   # Like V2 output, but meant for the CNB interface
-  class UserComms::CNB < UserComms::V2
+  class UserComms::CNB < UserComms::Base
+    def topic(message) # Aka "status"
+      banner message, color: "\033[1;38;2;157;112;208m"
+    end
+
+    # The default
+    def info(message = "\n")
+      message.to_s.each_line do |line|
+        string = +"[INFO]"
+        string << " #{line}" if !line.strip.empty?
+        string << "\n" unless string.end_with?("\n")
+        io.print string
+      end
+    end
+
+    def print_error_obj(error_obj)
+      banner "Error: #{error_obj.title}", color: "\033[1;38;2;0;0;0;48;2;214;65;65m"
+      info(error_obj.body)
+
+      return unless error_obj.link
+      info
+      info("Link: #{error_ob.link}")
+    end
+
+    def warn_now(title:, body:, link: nil)
+      banner "Warning: #{title}", color: "\033[1;38;2;0;0;0;48;2;250;159;71m"
+      info(body)
+
+      return unless link
+      info
+      info("Link: #{link}")
+    end
+
+    def notice(message)
+      banner "Notice: #{message}", color: "\033[1;38;2;64;143;236m"
+    end
+
+    private def banner(message, color: "", no_color: "\033[0m")
+      io.puts
+      io.puts("#{color}[#{message.strip}]#{no_color}")
+    end
   end
 
   class UserComms::Null < UserComms::V2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -119,3 +119,9 @@ def isolate_in_fork
     end
   end
 end
+
+class String
+  def strip_control_codes
+    self.gsub(/\e\[[^\x40-\x7E]*[\x40-\x7E]/, "")
+  end
+end

--- a/spec/unit/user_comms_spec.rb
+++ b/spec/unit/user_comms_spec.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper.rb"
+
+module HerokuBuildpackRuby
+  RSpec.describe "UserComms" do
+    it "bundle install" do
+      v2_io = StringIO.new
+      cnb_io = StringIO.new
+      [
+        UserComms::V2.new(v2_io),
+        UserComms::CNB.new(cnb_io),
+        UserComms::Null.new
+      ].each do |user_comms|
+        user_comms.topic "Compiling Ruby/Rails"
+        user_comms.info "Using Ruby version: ruby-2.7.1"
+        user_comms.topic "Installing dependencies using bundler 2.1.4"
+        user_comms.info "Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4"
+        user_comms.info <<~EOM
+           Fetching gem metadata from https://rubygems.org/............
+           Using rake 13.0.1
+           Using concurrent-ruby 1.1.6
+           Using minitest 5.14.1
+           Using thread_safe 0.3.6
+           Using zeitwerk 2.4.0
+           Using builder 3.2.4
+           Using erubi 1.9.0
+           Using mini_portile2 2.4.0
+           Using crass 1.0.6
+           Using rack 2.2.3
+           Using nio4r 2.5.4
+           Using websocket-extensions 0.1.5
+           Using mimemagic 0.3.5
+           Bundle complete! 76 Gemfile dependencies, 146 gems now installed.
+           Gems in the groups development and test were not installed.
+           Bundled gems are installed into `./vendor/bundle`
+        EOM
+        user_comms.notice "Bundle completed (4.14s)"
+        user_comms.warn_now(
+          title: "Update your Ruby version",
+          link: "https://devcenter.heroku.com/articles/ruby-support#supported-runtimes",
+          body: <<~EOM
+            There is a more recent Ruby version available for you to use:
+
+            2.7.2
+
+            The latest version will include security and bug fixes. We always recommend
+            running the latest version of your minor release.
+
+            Please upgrade your Ruby version.
+          EOM
+        )
+      end
+      # puts v2_io.string
+      expect(v2_io.string.strip_control_codes).to eq(<<~EOM)
+        -----> Compiling Ruby/Rails
+               Using Ruby version: ruby-2.7.1
+        -----> Installing dependencies using bundler 2.1.4
+               Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
+               Fetching gem metadata from https://rubygems.org/............
+               Using rake 13.0.1
+               Using concurrent-ruby 1.1.6
+               Using minitest 5.14.1
+               Using thread_safe 0.3.6
+               Using zeitwerk 2.4.0
+               Using builder 3.2.4
+               Using erubi 1.9.0
+               Using mini_portile2 2.4.0
+               Using crass 1.0.6
+               Using rack 2.2.3
+               Using nio4r 2.5.4
+               Using websocket-extensions 0.1.5
+               Using mimemagic 0.3.5
+               Bundle complete! 76 Gemfile dependencies, 146 gems now installed.
+               Gems in the groups development and test were not installed.
+               Bundled gems are installed into `./vendor/bundle`
+
+               ## Notice: Bundle completed (4.14s)
+
+               ## Warning: Update your Ruby version
+
+               There is a more recent Ruby version available for you to use:
+
+               2.7.2
+
+               The latest version will include security and bug fixes. We always recommend
+               running the latest version of your minor release.
+
+               Please upgrade your Ruby version.
+
+               Link: https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
+      EOM
+
+      # puts cnb_io.string
+      expect(cnb_io.string.strip_control_codes).to eq(<<~EOM)
+
+        [Compiling Ruby/Rails]
+        [INFO] Using Ruby version: ruby-2.7.1
+
+        [Installing dependencies using bundler 2.1.4]
+        [INFO] Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
+        [INFO] Fetching gem metadata from https://rubygems.org/............
+        [INFO] Using rake 13.0.1
+        [INFO] Using concurrent-ruby 1.1.6
+        [INFO] Using minitest 5.14.1
+        [INFO] Using thread_safe 0.3.6
+        [INFO] Using zeitwerk 2.4.0
+        [INFO] Using builder 3.2.4
+        [INFO] Using erubi 1.9.0
+        [INFO] Using mini_portile2 2.4.0
+        [INFO] Using crass 1.0.6
+        [INFO] Using rack 2.2.3
+        [INFO] Using nio4r 2.5.4
+        [INFO] Using websocket-extensions 0.1.5
+        [INFO] Using mimemagic 0.3.5
+        [INFO] Bundle complete! 76 Gemfile dependencies, 146 gems now installed.
+        [INFO] Gems in the groups development and test were not installed.
+        [INFO] Bundled gems are installed into `./vendor/bundle`
+
+        [Notice: Bundle completed (4.14s)]
+
+        [Warning: Update your Ruby version]
+        [INFO] There is a more recent Ruby version available for you to use:
+        [INFO]
+        [INFO] 2.7.2
+        [INFO]
+        [INFO] The latest version will include security and bug fixes. We always recommend
+        [INFO] running the latest version of your minor release.
+        [INFO]
+        [INFO] Please upgrade your Ruby version.
+        [INFO]
+        [INFO] Link: https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
+      EOM
+    end
+
+    it "makes poetry" do
+      v2_io = StringIO.new
+      cnb_io = StringIO.new
+      [
+        UserComms::V2.new(v2_io),
+        UserComms::CNB.new(cnb_io),
+        UserComms::Null.new
+      ].each do |user_comms|
+        user_comms.topic("The free bird leaps")
+        user_comms.info ""
+        user_comms.info "on the back of the wind"
+        user_comms.warn_now(
+          title: "and floats downstream",
+          link: "https://en.wikipedia.org/wiki/Maya_Angelou",
+          body: <<~EOM
+            till the current ends
+            and dips their wings
+            in the orange sun rays
+            and dares to claim the sky
+          EOM
+        )
+        user_comms.print_error_obj(
+          BuildpackErrorNoBacktrace.new(
+            title: "But a bird that stalks",
+            body: <<~EOM
+              down their narrow cage
+              can seldom see through
+              their bars of rage
+              their wings are clipped and
+              their feet are tied
+              so they opens their throat to sing.
+            EOM
+          )
+        )
+        user_comms.warn_later(
+          title: "The caged bird sings", body: <<~EOM
+            with fearful trill
+            of the things unknown
+            but longed for still
+            and his tune is heard
+            on the distant hill for the caged bird
+            sings of freedom
+          EOM
+        )
+        user_comms.close
+        user_comms.notice("I know why the caged bird sings")
+      end
+      # puts v2_io.string
+      expect(v2_io.string.strip_control_codes).to eq(<<~EOM)
+        -----> The free bird leaps
+               on the back of the wind
+
+               ## Warning: and floats downstream
+
+               till the current ends
+               and dips their wings
+               in the orange sun rays
+               and dares to claim the sky
+
+               Link: https://en.wikipedia.org/wiki/Maya_Angelou
+
+               ## Error: But a bird that stalks
+
+               !
+               !  down their narrow cage
+               !  can seldom see through
+               !  their bars of rage
+               !  their wings are clipped and
+               !  their feet are tied
+               !  so they opens their throat to sing.
+               !
+
+               ## Warning: The caged bird sings
+
+               with fearful trill
+               of the things unknown
+               but longed for still
+               and his tune is heard
+               on the distant hill for the caged bird
+               sings of freedom
+
+               ## Notice: I know why the caged bird sings
+      EOM
+
+      # puts cnb_io.string
+      expect(cnb_io.string.strip_control_codes).to eq(<<~EOM)
+
+        [The free bird leaps]
+        [INFO] on the back of the wind
+
+        [Warning: and floats downstream]
+        [INFO] till the current ends
+        [INFO] and dips their wings
+        [INFO] in the orange sun rays
+        [INFO] and dares to claim the sky
+        [INFO]
+        [INFO] Link: https://en.wikipedia.org/wiki/Maya_Angelou
+
+        [Error: But a bird that stalks]
+        [INFO] down their narrow cage
+        [INFO] can seldom see through
+        [INFO] their bars of rage
+        [INFO] their wings are clipped and
+        [INFO] their feet are tied
+        [INFO] so they opens their throat to sing.
+
+        [Warning: The caged bird sings]
+        [INFO] with fearful trill
+        [INFO] of the things unknown
+        [INFO] but longed for still
+        [INFO] and his tune is heard
+        [INFO] on the distant hill for the caged bird
+        [INFO] sings of freedom
+
+        [Notice: I know why the caged bird sings]
+      EOM
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a different "CNB" logging style to the buildpack. Other smaller changes:

- The UserComms class is now directly tested
- UserComms#puts now UserComms#info
- UserComms#warn_now takes kwargs instead of just a single message, this allows us to consistently format links and titles across the project
- UserComms#error raises an error that can be caught later instead of exiting immediately (this can be used later for cleanup handling the error)