### PR TITLE
[changelog skip] Jruby support - V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 - We will request node to be installed via the heroku/nodejs buildpack on your system when `package.json` is found but `which node` is not present
   - See heroku/nodejs for their application contract
+- We will request java to be installed via the heroku/jvm buildpack on your system when your Gemfile.lock specifies jruby but `which java` is not present
+  - See heroku/jvm for their application contract
 - We will determine a version of bundler for you based on the contents of your Gemfile.lock. You cannot specify the exact version, just major version i.e. 1.x or 2.x.
 - We will determine your requested version of Ruby using `bundle platform --ruby` (or similar logic).
 - We will install your gem dependencies using `bundle install`.

--- a/bin/compile
+++ b/bin/compile
@@ -6,10 +6,29 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-BIN_DIR=$(cd $(dirname "$0"); pwd)
+BIN_DIR=$(cd "$(dirname "$0")"; pwd)
 BUILDPACK_DIR=$(dirname "$BIN_DIR")
 
+# shellcheck source=bin/support/bash_functions.sh
 source "$BIN_DIR/support/bash_functions.sh"
+
+if detect_needs_java "$BUILD_DIR"; then
+  cat <<EOM
+
+       ## Warning: Your app needs java
+
+       The Ruby buildpack determined your app needs java installed
+       we recommend you add the node buildpack to your application:
+
+         $ heroku buildpacks:add heroku/jvm --index=1
+
+-----> Installing Java
+
+EOM
+
+  compile_buildpack_v2 "$BUILD_DIR" "$CACHE_DIR" "$ENV_DIR" "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz" "heroku/jvm"
+fi
+
 
 if needs_package_json "$BUILD_DIR"; then
   echo "      Writing package.json"
@@ -19,7 +38,7 @@ fi
 if detect_needs_node "$BUILD_DIR"; then
   cat <<EOM
 
-       ## Warning
+       ## Warning: Your app need node
 
        The Ruby buildpack determined your app needs node installed
        we recommend you add the node buildpack to your application:
@@ -37,7 +56,7 @@ fi
 
 bootstrap_ruby_to_buildpack_dir
 
-cat <<EOF | $(buildpack_ruby_path) -I$BUILDPACK_DIR/lib -rheroku_buildpack_ruby
+cat <<EOF | $(buildpack_ruby_path) -I"$BUILDPACK_DIR/lib" -rheroku_buildpack_ruby
   HerokuBuildpackRuby.compile_legacy(
     build_dir: '$BUILD_DIR',
     cache_dir: '$CACHE_DIR',

--- a/bin/detect
+++ b/bin/detect
@@ -19,6 +19,7 @@ fi
 set -eu
 PLAN=$2
 APP_DIR=$(pwd)
+BIN_DIR=$(cd "$(dirname "$0")"; pwd)
 
 if [ ! -f "$APP_DIR/Gemfile" ]; then
   echo "no"
@@ -27,7 +28,7 @@ else
   echo "Ruby"
 fi
 
-BIN_DIR=$(cd "$(dirname "$0")"; pwd)
+# shellcheck source=bin/support/bash_functions.sh
 source "$BIN_DIR/support/bash_functions.sh"
 
 write_to_build_plan "$PLAN" "$APP_DIR"

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -175,7 +175,7 @@ compile_buildpack_v2()
 # A wrapper for `which node` so we can stub it out in tests
 which_node()
 {
-  which node
+  which -s node
 }
 
 # Returns truthy if the project needs node installed but does not
@@ -268,3 +268,24 @@ write_to_build_plan()
     write_to_build_plan_ruby "$build_plan"
   fi
 }
+
+which_java()
+{
+  which -s java
+}
+
+# Detects if a given Gemfile.lock has jruby in it
+# $ cat Gemfile.lock | grep jruby # => ruby 2.5.7p001 (jruby 9.2.13.0)
+detect_needs_java()
+{
+  local app_dir=$1
+  local gemfile_lock="$app_dir/Gemfile.lock"
+  # local needs_jruby=0
+  local skip_java_install=1
+
+  if which_java; then
+    return $skip_java_install
+  fi
+  grep "(jruby " "$gemfile_lock" --quiet
+}
+

--- a/lib/heroku_buildpack_ruby/bash.rb
+++ b/lib/heroku_buildpack_ruby/bash.rb
@@ -67,7 +67,7 @@ module HerokuBuildpackRuby
     end
 
     def command_without_env
-      return @command if user_env&.empty?
+      return @command if !user_env || user_env.empty?
 
       @command.sub(user_env.to_shell, "<REDACTED>")
     end

--- a/lib/heroku_buildpack_ruby/bundle_install.rb
+++ b/lib/heroku_buildpack_ruby/bundle_install.rb
@@ -88,13 +88,15 @@ module HerokuBuildpackRuby
       end
     end
 
-    private def bundle_failed
-      message = String.new("Failed to install gems via Bundler.")
-      message << sqlite_error_message if bundler_output.match(/An error occurred while installing sqlite3/)
-      message << gemfile_ruby_version_error if bundler_output.match(/but your Gemfile specified/)
-      user_comms.error_and_exit(message)
+    private def bundle_install_fail
+      body = String.new(bundle_output)
+      body << sqlite_error_message if bundle_output.match(/An error occurred while installing sqlite3/)
+      body << gemfile_ruby_version_error if bundle_output.match(/but your Gemfile specified/)
+      user_comms.error(
+        title: "Failed to install gems via Bundler",
+        body: body
+      )
     end
-
 
     private def fix_bundle_without_space
       BUNDLE_WITHOUT_ENV.set_without_record(BUNDLE_WITHOUT_ENV.value.tr(" ", ":"))

--- a/lib/heroku_buildpack_ruby/curl_fetch.rb
+++ b/lib/heroku_buildpack_ruby/curl_fetch.rb
@@ -32,6 +32,14 @@ module HerokuBuildpackRuby
       @curl_command_prefix = "set -o pipefail; curl -L --fail --retry 5 --retry-delay 1 --connect-timeout 10 --max-time 120 ".freeze
     end
 
+    def exist?
+      Bash.new(
+        "#{@curl_command_prefix} -I #{@url}"
+      ).run
+      return $?.success?
+    end
+    alias :exists? :exist?
+
     def fetch_untar(files_to_extract: nil)
       Dir.chdir(@install_dir) do
         Bash.new(

--- a/lib/heroku_buildpack_ruby/ruby_detect_version.rb
+++ b/lib/heroku_buildpack_ruby/ruby_detect_version.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "pathname"
+require_relative "ruby_version_info.rb"
 
 module HerokuBuildpackRuby
   # Detects the app's Ruby version based off of Gemfile.lock contents or `bundle platform --ruby` output
@@ -56,9 +57,15 @@ module HerokuBuildpackRuby
     def call
       out = bundler_output
       if (md = RUBY_VERSION_REGEX.match(out))
-        @version = md[:ruby_version]
+        @version = RubyVersionInfo.new(
+          engine: md[:engine],
+          version: md[:ruby_version],
+          engine_version: md[:engine_version]
+        )
       else
-        @version = ruby_metadata.fetch(:default_version) { default_version }
+        @version = RubyVersionInfo.new(
+          version: ruby_metadata.fetch(:default_version) { default_version }
+        )
         warn_default_ruby
       end
       self

--- a/lib/heroku_buildpack_ruby/ruby_download.rb
+++ b/lib/heroku_buildpack_ruby/ruby_download.rb
@@ -13,18 +13,23 @@ module HerokuBuildpackRuby
       @version = version
       @user_comms = user_comms
       @install_dir = Pathname(install_dir).tap(&:mkpath)
+      @fetcher = CurlFetch.new(
+        "ruby-#{version}.tgz",
+        folder: stack,
+        install_dir: install_dir
+      )
 
       raise "Must provide a stack #{@stack} to download a Ruby version" if @stack.to_s.empty?
     end
 
+    def exist?
+      @fetcher.exist?
+    end
+    alias :exists? :exist?
+
     def call
       user_comms.info("Using Ruby version: #{version}")
-
-      CurlFetch.new(
-        "ruby-#{version}.tgz",
-        folder: stack,
-        install_dir: install_dir
-      ).fetch_untar
+      @fetcher.fetch_untar
     end
   end
 end

--- a/lib/heroku_buildpack_ruby/ruby_version_info.rb
+++ b/lib/heroku_buildpack_ruby/ruby_version_info.rb
@@ -1,0 +1,31 @@
+module HerokuBuildpackRuby
+  # It wraps version info and pretends to be a string
+  #
+  # Example:
+  #
+  #   v = RubyVersionInfo.new(version: "2.7.2")
+  #   puts v.to_s # => "2.7.2"
+  #
+  #   v = RubyVersionInfo.new(
+  #     version: "2.5.7",
+  #     engine: :jruby,
+  #     engine_version: "9.2.13.0"
+  #   )
+  #   puts v.to_s # => "2.5.7-jruby-9.2.13.0"
+  #
+  # There is strong coupling between this output and naming structure
+  # of Ruby binaries on S3
+  class RubyVersionInfo
+    attr_reader :version, :engine, :engine_version
+    def initialize(version: , engine: nil, engine_version: nil)
+      @engine = engine
+      @version = version
+      @engine_version = engine_version
+      @string = [version, engine, engine_version].compact.join("-")
+    end
+
+    def to_s
+      @string
+    end
+  end
+end

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -4,7 +4,7 @@ require_relative "../spec_helper.rb"
 
 module HerokuBuildpackRuby
   RSpec.describe "This buildpack" do
-    describe "jruby" do
+    it "jruby" do
       Hatchet::Runner.new("default_ruby").tap do |app|
         app.before_deploy do
           dir = Pathname(Dir.pwd)
@@ -26,10 +26,11 @@ module HerokuBuildpackRuby
 
             DEPENDENCIES
           EOM
-          dir.join("system.properties").write("java.runtime.version=1.7")
         end
         app.deploy do
-          puts app.output
+          expect(app.output).to include("Installing JDK")
+          expect(app.output).to include("Using Ruby version: 2.5.7-jruby-9.2.13.0")
+          expect(app.output).to include("Bundle complete")
         end
       end
     end

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -4,6 +4,36 @@ require_relative "../spec_helper.rb"
 
 module HerokuBuildpackRuby
   RSpec.describe "This buildpack" do
+    describe "jruby" do
+      Hatchet::Runner.new("default_ruby").tap do |app|
+        app.before_deploy do
+          dir = Pathname(Dir.pwd)
+          dir.join("Gemfile").write <<~EOM
+            source "https://rubygems.org"
+
+            ruby '2.5.7', engine: 'jruby', engine_version: '9.2.13.0'
+          EOM
+          dir.join("Gemfile.lock").write <<~EOM
+            GEM
+              remote: https://rubygems.org/
+              specs:
+
+            PLATFORMS
+              java
+
+            RUBY VERSION
+               ruby 2.5.7p001 (jruby 9.2.13.0)
+
+            DEPENDENCIES
+          EOM
+          dir.join("system.properties").write("java.runtime.version=1.7")
+        end
+        app.deploy do
+          puts app.output
+        end
+      end
+    end
+
     it "user env compile" do
       Hatchet::Runner.new("default_ruby", config: {"BUNDLE_WITHOUT": "periwinkle"}).tap do |app|
         app.before_deploy do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -125,3 +125,11 @@ class String
     self.gsub(/\e\[[^\x40-\x7E]*[\x40-\x7E]/, "")
   end
 end
+
+class Pathname
+  def self.mktmpdir
+    Dir.mktmpdir do |dir|
+      yield Pathname(dir)
+    end
+  end
+end

--- a/spec/unit/bash_functions_spec.rb
+++ b/spec/unit/bash_functions_spec.rb
@@ -51,6 +51,73 @@ module HerokuBuildpackRuby
       out
     end
 
+    it "Detects jruby in the Gemfile.lock" do
+      Pathname.mktmpdir do |dir|
+        dir.join("Gemfile.lock").write <<~EOM
+          RUBY VERSION
+             ruby 2.5.7p001 (jruby 9.2.13.0)
+        EOM
+
+
+        out = exec_with_bash_functions <<~EOM
+          which_java()
+          {
+            return 1
+          }
+
+          if detect_needs_java "#{dir}"; then
+            echo "jruby detected"
+          else
+            echo "nope"
+          fi
+        EOM
+
+        expect(out).to eq("jruby detected")
+
+        dir.join("Gemfile.lock").write <<~EOM
+        EOM
+
+        out = exec_with_bash_functions <<~EOM
+          which_java()
+          {
+            return 1
+          }
+
+          if detect_needs_java "#{dir}"; then
+            echo "jruby detected"
+          else
+            echo "nope"
+          fi
+        EOM
+
+        expect(out).to eq("nope")
+      end
+    end
+
+    it "Detects java for jruby detection" do
+      Pathname.mktmpdir do |dir|
+        dir.join("Gemfile.lock").write <<~EOM
+          RUBY VERSION
+             ruby 2.5.7p001 (jruby 9.2.13.0)
+        EOM
+
+        out = exec_with_bash_functions <<~EOM
+          which_java()
+          {
+            return 0
+          }
+
+          if detect_needs_java "#{dir}"; then
+            echo "jruby detected"
+          else
+            echo "already installed"
+          fi
+        EOM
+
+        expect(out).to eq("already installed")
+      end
+    end
+
     it "Downloads a ruby binary" do
       Dir.mktmpdir do |dir|
         exec_with_bash_functions <<~EOM

--- a/spec/unit/bash_spec.rb
+++ b/spec/unit/bash_spec.rb
@@ -14,6 +14,12 @@ module HerokuBuildpackRuby
       expect(bash.run.strip).to eq("Hello")
     end
 
+    it "accepts falsey user env when an error is raised" do
+      expect{
+        Bash.new('echo "negative"; exit 1', user_env: false).run!
+      }.to raise_error(/Bash command failed/)
+    end
+
     describe "on error" do
       it "can error on run!" do
         bash = Bash.new("echo 'nope'; exit1")

--- a/spec/unit/curl_fetch_spec.rb
+++ b/spec/unit/curl_fetch_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper.rb"
+
+module HerokuBuildpackRuby
+  RSpec.describe "CurlFetch" do
+    it "knows if binaries exist" do
+      Dir.mktmpdir do |dir|
+        fetcher = CurlFetch.new(
+          "ruby-2.7.2.tgz",
+          folder: "heroku-20",
+          install_dir: dir
+        )
+        expect(fetcher.exist?).to be_truthy
+
+        fetcher = CurlFetch.new(
+          "nope-nope-nope.tgz",
+          folder: "heroku-20",
+          install_dir: dir
+        )
+        expect(fetcher.exist?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/unit/prepare_app_bundler_and_ruby_spec.rb
+++ b/spec/unit/prepare_app_bundler_and_ruby_spec.rb
@@ -66,7 +66,7 @@ module HerokuBuildpackRuby
           )
           ruby_version = bootstrap.ruby_detect_version
 
-          expect(ruby_version).to eq("2.6.23")
+          expect(ruby_version.to_s).to eq("2.6.23")
         end
       end
     end

--- a/spec/unit/ruby_download_spec.rb
+++ b/spec/unit/ruby_download_spec.rb
@@ -6,13 +6,18 @@ module HerokuBuildpackRuby
   RSpec.describe "download ruby" do
     it "downloads a ruby" do
       Dir.mktmpdir do |dir|
-        RubyDownload.new(
+        dir = Pathname(dir)
+        download = RubyDownload.new(
           version: "2.7.2",
           stack: "heroku-18",
           install_dir: dir
-        ).call
+        )
 
-        entries = Dir.entries(dir) - [".", ".."]
+        expect(download.exist?).to be_truthy
+
+        download.call
+
+        entries = dir.entries.map(&:to_s)
         expect(entries).to include("bin")
         expect(entries).to include("include")
         expect(entries).to include("lib")

--- a/spec/unit/ruby_version_info_spec.rb
+++ b/spec/unit/ruby_version_info_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper.rb"
+
+module HerokuBuildpackRuby
+  RSpec.describe "RubyVersionInfo" do
+    it "acts like a string" do
+      v = RubyVersionInfo.new(version: "2.7.2")
+      expect("#{v}").to eq("2.7.2")
+    end
+
+    it "formats jruby" do
+      v = RubyVersionInfo.new(
+        engine: :jruby,
+        version: "2.5.7",
+        engine_version: "9.2.13.0"
+      )
+      expect("#{v}").to eq("2.5.7-jruby-9.2.13.0")
+    end
+
+    it "matches S3 format for jruby" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+
+        v = RubyVersionInfo.new(
+          engine: :jruby,
+          version: "2.5.7",
+          engine_version: "9.2.13.0"
+        )
+        download = RubyDownload.new(
+          version: v,
+          stack: "heroku-20",
+          install_dir: dir
+        )
+        expect(download).to exist
+      end
+    end
+
+    it "matches s3 format for ruby" do
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+
+        v = RubyVersionInfo.new(
+          version: "2.7.2",
+        )
+        download = RubyDownload.new(
+          version: v,
+          stack: "heroku-20",
+          install_dir: dir
+        )
+        expect(download).to exist
+      end
+    end
+  end
+end


### PR DESCRIPTION
When an app is deploying that need the JVM for JRuby we can lean on the heroku/jvm buildpack instead of managing our own java installation. This allows for separation of concerns and not having to duplicate logic.

This is similar to the v2 logic for Node.