### PR TITLE
[close #26][changelog skip] Use docker executor on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,22 +55,24 @@ jobs:
       - <<: *hatchet_setup
       - <<: *hatchet
   pack_cnb:
-    machine: true
+    docker:
+      - image: circleci/ruby:2.7
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 19.03.13
       - pack/install-pack
-      - ruby/install:
-          version: "2.7"
       - ruby/install-deps
       - <<: *hatchet_setup
       - <<: *pack_cnb
   docker_commands:
-    machine: true
+    docker:
+      - image: circleci/ruby:2.7
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 19.03.13
       - pack/install-pack
-      - ruby/install:
-          version: "2.7"
       - ruby/install-deps
       - <<: *hatchet_setup
       - <<: *docker_commands


### PR DESCRIPTION
The "machine" executor has a number of limitations and edge cases, not to mention that the RVM installation is very buggy and frequently causes the build to break.

This commit moves to use docker along with setting up "remote docker" https://circleci.com/docs/2.0/building-docker-images/