### PR TITLE
[changelog skip] CNB Request JVM in Detect

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require syntax_search/auto

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.1)
     diff-lcs (1.4.4)
     erubis (2.7.0)
     excon (0.78.0)
@@ -22,8 +21,6 @@ GEM
     parallel_split_test (0.8.0)
       parallel (>= 0.5.13)
       rspec (>= 3.1.0)
-    parser (2.7.2.0)
-      ast (~> 2.4.1)
     platform-api (3.0.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
@@ -45,8 +42,7 @@ GEM
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
     rspec-support (3.9.3)
-    syntax_search (0.1.1)
-      parser
+    syntax_search (0.1.4)
     thor (1.0.1)
     threaded (0.0.4)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 ## Application contract
 
-
 - We will request node to be installed via the heroku/nodejs buildpack on your system when `package.json` is found but `which node` is not present
   - See heroku/nodejs for their application contract
+  - [TODO] https://github.com/heroku/heroku-buildpack-ruby-experimental/issues/27
 - We will request java to be installed via the heroku/jvm buildpack on your system when your Gemfile.lock specifies jruby but `which java` is not present
   - See heroku/jvm for their application contract
+  - [TODO] https://github.com/heroku/heroku-buildpack-ruby-experimental/issues/36
 - We will determine a version of bundler for you based on the contents of your Gemfile.lock. You cannot specify the exact version, just major version i.e. 1.x or 2.x.
 - We will determine your requested version of Ruby using `bundle platform --ruby` (or similar logic).
 - We will install your gem dependencies using `bundle install`.

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -241,7 +241,7 @@ write_to_build_plan_java()
 
 cat << EOF >> "$build_plan"
 [[requires]]
-name = "java"
+name = "jdk"
 EOF
 }
 

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -222,20 +222,26 @@ detect_needs_node()
   fi
 }
 
-# Writes a plan.json that provides and requires ruby as well as asking for node
-write_to_build_plan_ruby_node()
+# Writes a plan.json that asks for node
+write_to_build_plan_node()
 {
   local build_plan=$1
 
-cat << EOF > "$build_plan"
-[[provides]]
-name = "ruby"
-
+cat << EOF >> "$build_plan"
 [[requires]]
 name = "node"
+EOF
+}
 
+# Writes a plan.json that asks for java
+write_to_build_plan_java()
+{
+
+  local build_plan=$1
+
+cat << EOF >> "$build_plan"
 [[requires]]
-name = "ruby"
+name = "java"
 EOF
 }
 
@@ -244,7 +250,7 @@ write_to_build_plan_ruby()
 {
   local build_plan=$1
 
-cat << EOF > "$build_plan"
+cat << EOF >> "$build_plan"
 [[provides]]
 name = "ruby"
 
@@ -268,10 +274,13 @@ write_to_build_plan()
   local build_dir=$2
 
   if detect_needs_node "$build_dir"; then
-    write_to_build_plan_ruby_node "$build_plan"
-  else
-    write_to_build_plan_ruby "$build_plan"
+    write_to_build_plan_node "$build_plan"
   fi
+
+  if detect_needs_java "$build_dir";then
+    write_to_build_plan_java "$build_plan"
+  fi
+  write_to_build_plan_ruby "$build_plan"
 }
 
 which_java()

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -126,10 +126,12 @@ class String
   end
 end
 
-class Pathname
-  def self.mktmpdir
-    Dir.mktmpdir do |dir|
-      yield Pathname(dir)
+class My
+  class Pathname
+    def self.mktmpdir
+      Dir.mktmpdir do |dir|
+        yield Pathname(dir)
+      end
     end
   end
 end

--- a/spec/unit/bash_functions_spec.rb
+++ b/spec/unit/bash_functions_spec.rb
@@ -183,7 +183,6 @@ module HerokuBuildpackRuby
 
         plan_path = build_dir.join("plan.toml")
         exec_with_bash_functions <<~EOM
-          # Stub out the call to `which node` so we can pretend it does NOT exist on the system
           which_java()
           {
             return 1

--- a/spec/unit/bash_functions_spec.rb
+++ b/spec/unit/bash_functions_spec.rb
@@ -52,7 +52,7 @@ module HerokuBuildpackRuby
     end
 
     it "Detects jruby in the Gemfile.lock" do
-      Pathname.mktmpdir do |dir|
+      My::Pathname.mktmpdir do |dir|
         dir.join("Gemfile.lock").write <<~EOM
           RUBY VERSION
              ruby 2.5.7p001 (jruby 9.2.13.0)
@@ -95,7 +95,7 @@ module HerokuBuildpackRuby
     end
 
     it "Detects java for jruby detection" do
-      Pathname.mktmpdir do |dir|
+      My::Pathname.mktmpdir do |dir|
         dir.join("Gemfile.lock").write <<~EOM
           RUBY VERSION
              ruby 2.5.7p001 (jruby 9.2.13.0)
@@ -119,7 +119,7 @@ module HerokuBuildpackRuby
     end
 
     it "Downloads a ruby binary" do
-      Dir.mktmpdir do |dir|
+      My::Pathname.mktmpdir do |dir|
         exec_with_bash_functions <<~EOM
 
           download_ruby "2.6.6" "#{dir}"
@@ -140,8 +140,7 @@ module HerokuBuildpackRuby
     end
 
     it "downloads ruby to BUILDPACK_DIR vendor directory" do
-      Dir.mktmpdir do |dir|
-        dir = Pathname(dir)
+      My::Pathname.mktmpdir do |dir|
 
         exec_with_bash_functions(<<~EOM, stack: "heroku-18")
           BUILDPACK_DIR="#{dir}"
@@ -156,8 +155,7 @@ module HerokuBuildpackRuby
     end
 
     it "bootstraps ruby using toml file" do
-      Dir.mktmpdir do |dir|
-        dir = Pathname(dir)
+      My::Pathname.mktmpdir do |dir|
 
         FileUtils.cp(
           root_dir.join("buildpack.toml"), # From
@@ -222,9 +220,7 @@ module HerokuBuildpackRuby
     end
 
     it "does not output node when node is already installed" do
-      Dir.mktmpdir do |dir|
-        build_dir = Pathname(dir)
-
+      My::Pathname.mktmpdir do |build_dir|
         build_dir.join("package.json").write "{}"
 
         plan_path = build_dir.join("plan.toml")
@@ -247,8 +243,7 @@ module HerokuBuildpackRuby
     end
 
     it "detects if execjs is present" do
-      Dir.mktmpdir do |dir|
-        build_dir = Pathname(dir)
+      My::Pathname.mktmpdir do |build_dir|
         package_json = build_dir.join("package.json")
         expect(package_json).to_not be_file
 
@@ -283,9 +278,7 @@ module HerokuBuildpackRuby
     end
 
     it "outputs a ruby plan" do
-      Dir.mktmpdir do |dir|
-        build_dir = Pathname(dir)
-
+      My::Pathname.mktmpdir do |build_dir|
         plan_path = build_dir.join("plan.toml")
         exec_with_bash_functions <<~EOM
           write_to_build_plan "#{plan_path}" "#{build_dir}"

--- a/spec/unit/bash_functions_spec.rb
+++ b/spec/unit/bash_functions_spec.rb
@@ -194,7 +194,7 @@ module HerokuBuildpackRuby
         toml = TOML.load(plan_path.read)
 
         expect(toml).to include(provides: [{name: "ruby"}])
-        expect(toml).to include(requires: [{name: "java"}, {name: "ruby"}])
+        expect(toml).to include(requires: [{name: "jdk"}, {name: "ruby"}])
       end
     end
 


### PR DESCRIPTION
This PR makes the "build plan" bash functions more modular by appending to the file instead of overriding it. This allows us to append on jvm without requiring a matrix of feature support.

I've added an integration test for this behavior, but eventually, we need to modify the Ruby builder so that the JVM buildpack is in the default detect order (A similar PR is done in https://github.com/heroku/pack-images/pull/132, though it is pending work described in https://github.com/heroku/heroku-buildpack-ruby-experimental/issues/27).

I'll go ahead and merge this in before the builder work is complete. That work is being tracked in an issue. https://github.com/heroku/heroku-buildpack-ruby-experimental/issues/36