### PR TITLE
[changelog skip] Default process types

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@
     - We will limit or prune the size of this asset cache [TODO]
     - We will cache asset "fragments" directories if the `sprockets` gem is on the system [TODO]
 
+- We will set a default "console" process type based on the contents of your Gemfile.lock
+  - Use the Procfile to override
+- We will set a default "web" process type based on the contents of your Gemfile.lock
+  - Use the Procfile to override
+
 Goal: Convert all "may" statements to a more specific "will" so we're explicit about when thing shappen
 
 ## Internal Concepts

--- a/bin/release
+++ b/bin/release
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+
+BUILD_DIR=$1
+
+cat "$BUILD_DIR"/.heroku/ruby/release.yml

--- a/lib/heroku_buildpack_ruby.rb
+++ b/lib/heroku_buildpack_ruby.rb
@@ -11,6 +11,8 @@ require_relative "heroku_buildpack_ruby/metadata.rb"
 require_relative "heroku_buildpack_ruby/rake_detect.rb"
 require_relative "heroku_buildpack_ruby/assets_precompile.rb"
 
+require_relative "heroku_buildpack_ruby/default_process_types.rb"
+
 # This is the main entry point for the Ruby buildpack
 #
 # Legacy/V2 interface:

--- a/lib/heroku_buildpack_ruby.rb
+++ b/lib/heroku_buildpack_ruby.rb
@@ -11,7 +11,7 @@ require_relative "heroku_buildpack_ruby/metadata.rb"
 require_relative "heroku_buildpack_ruby/rake_detect.rb"
 require_relative "heroku_buildpack_ruby/assets_precompile.rb"
 
-require_relative "heroku_buildpack_ruby/default_process_types.rb"
+require_relative "heroku_buildpack_ruby/release_launch_info.rb"
 
 # This is the main entry point for the Ruby buildpack
 #
@@ -99,6 +99,10 @@ module HerokuBuildpackRuby
         has_assets_precompile: rake.detect?("assets:precompile"),
       ).call
 
+      ReleaseLaunchInfo::V2.new(
+        lockfile: lockfile,
+        vendor_dir: cache_dir
+      ).call
       EnvProxy.export(
         app_dir: app_dir,
         export_path: export,
@@ -162,11 +166,14 @@ module HerokuBuildpackRuby
         has_assets_precompile: rake.detect?("assets:precompile"),
       ).call
 
+      ReleaseLaunchInfo::CNB.new(
+        lockfile: lockfile,
+        layers_dir: layers_dir
+      ).call
       EnvProxy.write_layers(
         layers_dir: layers_dir
       )
       user_comms.close
-
     rescue BuildpackErrorNoBacktrace => e
       user_comms.print_error_obj(e)
       exit(1)

--- a/lib/heroku_buildpack_ruby.rb
+++ b/lib/heroku_buildpack_ruby.rb
@@ -101,7 +101,7 @@ module HerokuBuildpackRuby
 
       ReleaseLaunchInfo::V2.new(
         lockfile: lockfile,
-        vendor_dir: cache_dir
+        vendor_dir: vendor_dir
       ).call
       EnvProxy.export(
         app_dir: app_dir,

--- a/lib/heroku_buildpack_ruby/default_process_types.rb
+++ b/lib/heroku_buildpack_ruby/default_process_types.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module HerokuBuildpackRuby
+  class DefaultProcessTypes
+    private; attr_reader :deps, :rack, :railties, :thin; public
+
+    def initialize(deps)
+      @thin = deps.version("thin")
+      @rack = deps.version("rack")
+      @railties = deps.version("railties")
+      @process_hash = { console: "bundle exec irb" }
+
+      case
+      when railties
+        set_rails_types
+      when rack
+        set_rack_types
+      end
+    end
+
+    def to_h
+      @process_hash
+    end
+
+    private def set_rails_types
+      case
+      when railties >= Gem::Version.new("4.0")
+        set_rails_4_types
+      when railties >= Gem::Version.new("3.0")
+        set_rails_3_types
+      else
+        raise "Unsupported version of rails: #{railties}"
+      end
+    end
+
+    private def set_rails_4_types
+      @process_hash[:web]     = "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV"
+      @process_hash[:console] = "bin/rails console"
+    end
+
+    private def set_rails_3_types
+      @process_hash[:console] = "bundle exec rails console"
+      if thin
+        @process_hash[:web] = "bundle exec thin start -R config.ru -e $RAILS_ENV -p ${PORT:-5000}"
+      else
+        @process_hash[:web] = "bundle exec rails server -p ${PORT:-5000}"
+      end
+    end
+
+    private def set_rack_types
+      if thin
+        @process_hash[:web] = "bundle exec thin start -R config.ru -e $RACK_ENV -p ${PORT:-5000}"
+      else
+        @process_hash[:web] = "bundle exec rackup config.ru -p ${PORT:-5000}"
+      end
+    end
+  end
+end

--- a/lib/heroku_buildpack_ruby/default_process_types.rb
+++ b/lib/heroku_buildpack_ruby/default_process_types.rb
@@ -1,13 +1,22 @@
 # frozen_string_literal: true
 
 module HerokuBuildpackRuby
+  # Returns default process types for a given lockfile
+  #
+  #   lockfile = BundlerLockfileParser.new(
+  #     gemfile_lock_path: "./Gemfile.lock",
+  #     bundler_install_dir: bundler_install_dir
+  #   ).call
+  #
+  #   process_types = DefaultProcessTypes(lockfile).to_h
+  #   puts process_types[:console] # => "bundle exec irb"
   class DefaultProcessTypes
     private; attr_reader :deps, :rack, :railties, :thin; public
 
-    def initialize(deps)
-      @thin = deps.version("thin")
-      @rack = deps.version("rack")
-      @railties = deps.version("railties")
+    def initialize(lockfile)
+      @thin = lockfile.version("thin")
+      @rack = lockfile.version("rack")
+      @railties = lockfile.version("railties")
       @process_hash = { console: "bundle exec irb" }
 
       case

--- a/lib/heroku_buildpack_ruby/default_process_types.rb
+++ b/lib/heroku_buildpack_ruby/default_process_types.rb
@@ -25,6 +25,7 @@ module HerokuBuildpackRuby
       when rack
         set_rack_types
       end
+      @process_hash.transform_keys!(&:to_s)
     end
 
     def to_h

--- a/lib/heroku_buildpack_ruby/release_launch_info.rb
+++ b/lib/heroku_buildpack_ruby/release_launch_info.rb
@@ -20,7 +20,7 @@ module HerokuBuildpackRuby
     #   EOM
     class V2
       def initialize(lockfile:, vendor_dir:)
-        @release_yml_path = Pathname(vendor_dir).join("ruby", "release.yml").tap {|p| p.dirname.mkpath; FileUtils.touch(p)}
+        @release_yml_path = Pathname(vendor_dir).join("release.yml").tap {|p| p.dirname.mkpath; FileUtils.touch(p)}
         @process_types = DefaultProcessTypes.new(lockfile)
       end
 

--- a/lib/heroku_buildpack_ruby/release_launch_info.rb
+++ b/lib/heroku_buildpack_ruby/release_launch_info.rb
@@ -14,9 +14,9 @@ module HerokuBuildpackRuby
     #
     #   expect(vendor_dir.read).to eq(<<~EOM)
     #     ---
-    #     :default_process_types:
-    #       :console: bin/rails console
-    #       :web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
+    #     default_process_types:
+    #       console: bin/rails console
+    #       web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
     #   EOM
     class V2
       def initialize(lockfile:, vendor_dir:)
@@ -27,6 +27,7 @@ module HerokuBuildpackRuby
       def to_yaml
         yaml = YAML.load(@release_yml_path.read) || {}
         yaml[:default_process_types] = @process_types.to_h
+        yaml.transform_keys!(&:to_s)
         YAML.dump(yaml)
       end
 
@@ -46,10 +47,10 @@ module HerokuBuildpackRuby
     #   expect(vendor_dir.read).to eq(<<~EOM)
     #     [[processes]]
     #     command = "bin/rails console"
-    #     type = :console
+    #     type = "console"
     #     [[processes]]
     #     command = "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV"
-    #     type = :web
+    #     type = "web"
     #   EOM
     class CNB
       def initialize(lockfile:, layers_dir:)

--- a/lib/heroku_buildpack_ruby/release_launch_info.rb
+++ b/lib/heroku_buildpack_ruby/release_launch_info.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "yaml"
+require_relative "default_process_types.rb"
+
+module HerokuBuildpackRuby
+  class ReleaseLaunchInfo
+    # Writes out info for a release (v2) or launch (CNB)
+    #
+    #   ReleaseLaunchInfo::V2.new(
+    #     lockfile: lockfile,
+    #     vendor_dir: vendor_dir
+    #   ).call
+    #
+    #   expect(vendor_dir.read).to eq(<<~EOM)
+    #     ---
+    #     :default_process_types:
+    #       :console: bin/rails console
+    #       :web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
+    #   EOM
+    class V2
+      def initialize(lockfile:, vendor_dir:)
+        @release_yml_path = Pathname(vendor_dir).join("ruby", "release.yml").tap {|p| p.dirname.mkpath; FileUtils.touch(p)}
+        @process_types = DefaultProcessTypes.new(lockfile)
+      end
+
+      def to_yaml
+        yaml = YAML.load(@release_yml_path.read) || {}
+        yaml[:default_process_types] = @process_types.to_h
+        YAML.dump(yaml)
+      end
+
+      def call
+        @release_yml_path.write(to_yaml)
+      end
+    end
+
+    # Writes out info for a launch (CNB)
+    #
+    #   ReleaseLaunchInfo::V2.new(
+    #     lockfile: lockfile,
+    #     layers_dir: layers_dir
+    #   ).call
+    #
+    #
+    #   expect(vendor_dir.read).to eq(<<~EOM)
+    #     [[processes]]
+    #     command = "bin/rails console"
+    #     type = :console
+    #     [[processes]]
+    #     command = "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV"
+    #     type = :web
+    #   EOM
+    class CNB
+      def initialize(lockfile:, layers_dir:)
+        @launch_toml_path = Pathname(layers_dir).join("launch.toml").tap {|p| p.dirname.mkpath; FileUtils.touch(p)}
+        @process_types = DefaultProcessTypes.new(lockfile)
+      end
+
+      def to_toml
+        toml = TOML.load(@launch_toml_path) || {}
+
+        toml[:processes] = @process_types.to_h.map do |type, command|
+          { type: type, command: command}
+        end
+
+        TOML.dump(toml)
+      end
+
+      def call
+        @launch_toml_path.write(to_toml)
+      end
+    end
+  end
+end

--- a/spec/cnb/buildpack_spec.rb
+++ b/spec/cnb/buildpack_spec.rb
@@ -51,7 +51,7 @@ class CnbRun
   end
 
   def run(cmd)
-    command = %Q{docker run #{image_name} #{cmd.to_s.shellescape} 2>&1}
+    command = %Q{docker run --entrypoint="/cnb/lifecycle/launcher" #{image_name} #{cmd.to_s.shellescape} 2>&1}
     `#{command}`.strip
   end
 

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -72,10 +72,6 @@ module HerokuBuildpackRuby
 
       Hatchet::Runner.new("default_ruby", run_multi: true).tap do |app|
         app.before_deploy do
-          # TODO default process types
-          Pathname(Dir.pwd).join("Procfile").write <<~EOM
-            web: # No-op, needed so we can scale up for run_multi
-          EOM
           Pathname(Dir.pwd)
             .join("Gemfile.lock")
             .write("BUNDLED WITH\n   2.1.4", mode: "a")
@@ -124,11 +120,6 @@ module HerokuBuildpackRuby
       skip("Must set HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
 
       Hatchet::Runner.new("minimal_webpacker", run_multi: true).tap do |app|
-        app.before_deploy do
-          Pathname(Dir.pwd).join("Procfile").write <<~EOM
-            web: # No-op, needed so we can scale up for run_multi
-          EOM
-        end
         app.deploy do
           # This output comes from the heroku/nodejs buildpack
           expect(app.output).to include("installing yarn")

--- a/spec/unit/default_process_types_spec.rb
+++ b/spec/unit/default_process_types_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper.rb"
+
+module HerokuBuildpackRuby
+  RSpec.describe "Default process types" do
+    it "specifies console when there are no dependencies" do
+      deps = Object.new
+      def deps.version(name); end
+
+      expect(
+        DefaultProcessTypes.new(deps).to_h
+      ).to eq({console: "bundle exec irb"})
+    end
+
+    it "works with rack apps" do
+      deps = Object.new
+      def deps.version(name)
+        return Gem::Version.new("2.0") if name == "rack"
+      end
+
+      expect(
+        DefaultProcessTypes.new(deps).to_h
+      ).to eq(
+        {
+          web: "bundle exec rackup config.ru -p ${PORT:-5000}",
+          console: "bundle exec irb",
+        }
+      )
+    end
+
+    it "works with rack apps with thin" do
+      deps = Object.new
+      def deps.version(name)
+        return Gem::Version.new("2.0") if name == "rack"
+        return Gem::Version.new("2.0") if name == "thin"
+      end
+
+      expect(
+        DefaultProcessTypes.new(deps).to_h
+      ).to eq(
+        {
+          web: "bundle exec thin start -R config.ru -e $RACK_ENV -p ${PORT:-5000}",
+          console: "bundle exec irb",
+        }
+      )
+    end
+
+    it "works with rails 3 apps" do
+      deps = Object.new
+      def deps.version(name)
+        return Gem::Version.new("3.0") if name == "railties"
+      end
+
+      expect(
+        DefaultProcessTypes.new(deps).to_h
+      ).to eq(
+        {
+          web: "bundle exec rails server -p ${PORT:-5000}",
+          console: "bundle exec rails console",
+        }
+      )
+    end
+
+    it "works with rails 3 apps with thin" do
+      deps = Object.new
+      def deps.version(name)
+        return Gem::Version.new("3.0") if name == "railties"
+        return Gem::Version.new("2.0") if name == "thin"
+      end
+
+      expect(
+        DefaultProcessTypes.new(deps).to_h
+      ).to eq(
+        {
+          web: "bundle exec thin start -R config.ru -e $RAILS_ENV -p ${PORT:-5000}",
+          console: "bundle exec rails console",
+        }
+      )
+    end
+
+    it "works with rails 4 apps" do
+      deps = Object.new
+      def deps.version(name)
+        return Gem::Version.new("4.0") if name == "railties"
+      end
+
+      expect(
+        DefaultProcessTypes.new(deps).to_h
+      ).to eq(
+        {
+          web: "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV",
+          console: "bin/rails console",
+        }
+      )
+    end
+
+    it "works with rails 6 apps with rack" do
+      deps = Object.new
+      def deps.version(name)
+        return Gem::Version.new("6.0") if name == "railties"
+        return Gem::Version.new("6.0") if name == "rack"
+      end
+
+      expect(
+        DefaultProcessTypes.new(deps).to_h
+      ).to eq(
+        {
+          web: "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV",
+          console: "bin/rails console",
+        }
+      )
+    end
+  end
+end

--- a/spec/unit/default_process_types_spec.rb
+++ b/spec/unit/default_process_types_spec.rb
@@ -10,7 +10,7 @@ module HerokuBuildpackRuby
 
       expect(
         DefaultProcessTypes.new(deps).to_h
-      ).to eq({console: "bundle exec irb"})
+      ).to eq({"console" => "bundle exec irb"})
     end
 
     it "works with rack apps" do
@@ -23,8 +23,8 @@ module HerokuBuildpackRuby
         DefaultProcessTypes.new(deps).to_h
       ).to eq(
         {
-          web: "bundle exec rackup config.ru -p ${PORT:-5000}",
-          console: "bundle exec irb",
+          "web" => "bundle exec rackup config.ru -p ${PORT:-5000}",
+          "console" => "bundle exec irb",
         }
       )
     end
@@ -40,8 +40,8 @@ module HerokuBuildpackRuby
         DefaultProcessTypes.new(deps).to_h
       ).to eq(
         {
-          web: "bundle exec thin start -R config.ru -e $RACK_ENV -p ${PORT:-5000}",
-          console: "bundle exec irb",
+          "web" => "bundle exec thin start -R config.ru -e $RACK_ENV -p ${PORT:-5000}",
+          "console" => "bundle exec irb",
         }
       )
     end
@@ -56,8 +56,8 @@ module HerokuBuildpackRuby
         DefaultProcessTypes.new(deps).to_h
       ).to eq(
         {
-          web: "bundle exec rails server -p ${PORT:-5000}",
-          console: "bundle exec rails console",
+          "web" => "bundle exec rails server -p ${PORT:-5000}",
+          "console" => "bundle exec rails console",
         }
       )
     end
@@ -73,8 +73,8 @@ module HerokuBuildpackRuby
         DefaultProcessTypes.new(deps).to_h
       ).to eq(
         {
-          web: "bundle exec thin start -R config.ru -e $RAILS_ENV -p ${PORT:-5000}",
-          console: "bundle exec rails console",
+          "web" => "bundle exec thin start -R config.ru -e $RAILS_ENV -p ${PORT:-5000}",
+          "console" => "bundle exec rails console",
         }
       )
     end
@@ -89,8 +89,8 @@ module HerokuBuildpackRuby
         DefaultProcessTypes.new(deps).to_h
       ).to eq(
         {
-          web: "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV",
-          console: "bin/rails console",
+          "web" => "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV",
+          "console" => "bin/rails console",
         }
       )
     end
@@ -106,10 +106,11 @@ module HerokuBuildpackRuby
         DefaultProcessTypes.new(deps).to_h
       ).to eq(
         {
-          web: "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV",
-          console: "bin/rails console",
+          "web" => "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV",
+          "console" => "bin/rails console",
         }
       )
     end
   end
 end
+

--- a/spec/unit/release_launch_info_spec.rb
+++ b/spec/unit/release_launch_info_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper.rb"
+
+module HerokuBuildpackRuby
+  RSpec.describe "env proxy" do
+    describe "v2" do
+      it "generates yaml" do
+        My::Pathname.mktmpdir do |dir|
+          lockfile = Object.new
+          def lockfile.version(name);
+            return Gem::Version.new("6.0") if name == "railties"
+          end
+
+          expect(
+            ReleaseLaunchInfo::V2.new(
+              lockfile: lockfile,
+              vendor_dir: dir
+            ).to_yaml
+          ).to eq(<<~EOM)
+            ---
+            :default_process_types:
+              :console: bin/rails console
+              :web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
+          EOM
+        end
+      end
+
+      it "writes yaml" do
+        My::Pathname.mktmpdir do |dir|
+          lockfile = Object.new
+          def lockfile.version(name);
+            return Gem::Version.new("6.0") if name == "railties"
+          end
+
+          ReleaseLaunchInfo::V2.new(
+            lockfile: lockfile,
+            vendor_dir: dir
+          ).call
+          expect(
+            dir.join("ruby", "release.yml").read
+          ).to eq(<<~EOM)
+            ---
+            :default_process_types:
+              :console: bin/rails console
+              :web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
+          EOM
+        end
+      end
+    end
+
+    describe "cnb" do
+      it "generates toml" do
+        My::Pathname.mktmpdir do |dir|
+          lockfile = Object.new
+          def lockfile.version(name);
+            return Gem::Version.new("6.0") if name == "railties"
+          end
+
+          expect(
+            ReleaseLaunchInfo::CNB.new(
+              lockfile: lockfile,
+              layers_dir: dir
+            ).to_toml
+          ).to eq(<<~EOM)
+            [[processes]]
+            command = "bin/rails console"
+            type = :console
+            [[processes]]
+            command = "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV"
+            type = :web
+          EOM
+        end
+      end
+
+      it "writes toml" do
+        My::Pathname.mktmpdir do |dir|
+          lockfile = Object.new
+          def lockfile.version(name);
+            return Gem::Version.new("6.0") if name == "railties"
+          end
+
+          ReleaseLaunchInfo::CNB.new(
+            lockfile: lockfile,
+            layers_dir: dir
+          ).call
+
+          expect(
+            dir.join("launch.toml").read
+          ).to eq(<<~EOM)
+            [[processes]]
+            command = "bin/rails console"
+            type = :console
+            [[processes]]
+            command = "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV"
+            type = :web
+          EOM
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/release_launch_info_spec.rb
+++ b/spec/unit/release_launch_info_spec.rb
@@ -38,7 +38,7 @@ module HerokuBuildpackRuby
             vendor_dir: dir
           ).call
           expect(
-            dir.join("ruby", "release.yml").read
+            dir.join("release.yml").read
           ).to eq(<<~EOM)
             ---
             :default_process_types:

--- a/spec/unit/release_launch_info_spec.rb
+++ b/spec/unit/release_launch_info_spec.rb
@@ -19,9 +19,9 @@ module HerokuBuildpackRuby
             ).to_yaml
           ).to eq(<<~EOM)
             ---
-            :default_process_types:
-              :console: bin/rails console
-              :web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
+            default_process_types:
+              console: bin/rails console
+              web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
           EOM
         end
       end
@@ -41,9 +41,9 @@ module HerokuBuildpackRuby
             dir.join("release.yml").read
           ).to eq(<<~EOM)
             ---
-            :default_process_types:
-              :console: bin/rails console
-              :web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
+            default_process_types:
+              console: bin/rails console
+              web: bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
           EOM
         end
       end
@@ -65,10 +65,10 @@ module HerokuBuildpackRuby
           ).to eq(<<~EOM)
             [[processes]]
             command = "bin/rails console"
-            type = :console
+            type = "console"
             [[processes]]
             command = "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV"
-            type = :web
+            type = "web"
           EOM
         end
       end
@@ -90,10 +90,10 @@ module HerokuBuildpackRuby
           ).to eq(<<~EOM)
             [[processes]]
             command = "bin/rails console"
-            type = :console
+            type = "console"
             [[processes]]
             command = "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV"
-            type = :web
+            type = "web"
           EOM
         end
       end


### PR DESCRIPTION
Currently here's how the process types are defined.

- Type: "rake"
  - Not needed `heroku run rake` will execute correctly without a custom process type
  - Having this here makes `heroku run rake` a special case that can be difficult to debug if there's a problem with `bundle exec"
- Type: "console"
  - Ruby: "bundle exec irb"
  - Rails 2: "bundle exec script/console" # Drop Rails 2 support
  - Rails 3: "bundle exec rails console"
  - Rails 4: "bin/rails console"
- Type: "web"
  - Ruby: None
  - Rack:
    - Thin:    "bundle exec thin start -R config.ru -e $RACK_ENV -p ${PORT:-5000}" :
    - No thin: "bundle exec rackup config.ru -p ${PORT:-5000}"
  - Rails 2: # Drop Rails 2 support
    - Thin:    "bundle exec thin start -e $RAILS_ENV -p ${PORT:-5000}"
    - No thin: "bundle exec ruby script/server -p ${PORT:-5000}"
  - Rails 3:
    - Thin:    "bundle exec thin start -R config.ru -e $RAILS_ENV -p ${PORT:-5000}"
    - No thin: "bundle exec rails server -p ${PORT:-5000}"
  - Rails 4:
    - All:     "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV"

This implements the same interface but drops support for Rails 2 and drops the "rack" default process type.

Here' the details of each:

## Ruby

    def default_process_types
      instrument "ruby.default_process_types" do
        {
          "rake"    => "bundle exec rake",
          "console" => "bundle exec irb"
        }
      end
    end


## Rack

    def default_process_types
      instrument "rack.default_process_types" do
        # let's special case thin here if we detect it
        web_process = bundler.has_gem?("thin") ?
          "bundle exec thin start -R config.ru -e $RACK_ENV -p ${PORT:-5000}" :
          "bundle exec rackup config.ru -p ${PORT:-5000}"

        super.merge({
          "web" => web_process
        })
      end
    end

## Rails 2

    def default_process_types
      instrument "rails2.default_process_types" do
        web_process = bundler.has_gem?("thin") ?
          "bundle exec thin start -e $RAILS_ENV -p ${PORT:-5000}" :
          "bundle exec ruby script/server -p ${PORT:-5000}"

        process_types = super
        process_types["web"]     = web_process
        process_types["worker"]  = "bundle exec rake jobs:work" if has_jobs_work_task?
        process_types["console"] = "bundle exec script/console"
        process_types
      end
    end


## Rails 3

    def default_process_types
      instrument "rails3.default_process_types" do
        # let's special case thin here
        web_process = bundler.has_gem?("thin") ?
          "bundle exec thin start -R config.ru -e $RAILS_ENV -p ${PORT:-5000}" :
          "bundle exec rails server -p ${PORT:-5000}"

        super.merge({
          "web" => web_process,
          "console" => "bundle exec rails console"
        })
      end
    end


## Rails 4 and beyond

    def default_process_types
      instrument "rails4.default_process_types" do
        super.merge({
          "web"     => "bin/rails server -p ${PORT:-5000} -e $RAILS_ENV",
          "console" => "bin/rails console"
        })
      end
    end

