### PR TITLE
[changelog skip] Use named variables instead of bash args

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    dead_end (1.1.0)
+    dead_end (1.1.4)
     diff-lcs (1.4.4)
     erubis (2.7.0)
-    excon (0.78.0)
-    heroics (0.1.1)
+    excon (0.79.0)
+    heroics (0.1.2)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
+      webrick
     heroku_hatchet (7.3.3)
       excon (~> 0)
       platform-api (~> 3)
@@ -45,6 +46,7 @@ GEM
     rspec-support (3.9.3)
     thor (1.0.1)
     threaded (0.0.4)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby

--- a/bin/build
+++ b/bin/build
@@ -19,11 +19,11 @@ bootstrap_ruby_to_buildpack_dir
 
 cat <<EOF | $(buildpack_ruby_path) -I"$BUILDPACK_DIR/lib" -rheroku_buildpack_ruby
   HerokuBuildpackRuby.build_cnb(
-    layers_dir: '$LAYERS_DIR',
-    platform_dir: '$PLATFORM_DIR',
-    env_dir: '$ENV_DIR',
     plan: '$PLAN',
     app_dir: '$APP_DIR',
+    env_dir: '$ENV_DIR',
+    layers_dir: '$LAYERS_DIR',
+    platform_dir: '$PLATFORM_DIR',
     buildpack_ruby_path: '$(buildpack_ruby_path)',
    )
 EOF

--- a/bin/compile
+++ b/bin/compile
@@ -19,7 +19,7 @@ if detect_needs_java "$BUILD_DIR"; then
        ## Warning: Your app needs java
 
        The Ruby buildpack determined your app needs java installed
-       we recommend you add the node buildpack to your application:
+       we recommend you add this buildpack to your application:
 
          $ heroku buildpacks:add heroku/jvm --index=1
 
@@ -39,10 +39,10 @@ fi
 if detect_needs_node "$BUILD_DIR"; then
   cat <<EOM
 
-       ## Warning: Your app need node
+       ## Warning: Your app needs node
 
        The Ruby buildpack determined your app needs node installed
-       we recommend you add the node buildpack to your application:
+       we recommend you add this buildpack to your application:
 
          $ heroku buildpacks:add heroku/nodejs --index=1
 

--- a/bin/support/bash_functions.sh
+++ b/bin/support/bash_functions.sh
@@ -113,24 +113,28 @@ buildpack_ruby_path()
 #
 compile_buildpack_v2()
 {
-  # BUILD_DIR=$1
-  # CACHE_DIR=$2
-  # ENV_DIR=$3
-  BUILDPACK=$4
-  NAME=$5
+  local build_dir=$1
+  local cache_dir=$2
+  local env_dir=$3
+  local buildpack=$4
+  local name=$5
+
+  local dir
+  local url
+  local branch
 
   dir=$(mktemp -t buildpackXXXXX)
   rm -rf "$dir"
 
-  url=${BUILDPACK%#*}
-  branch=${BUILDPACK#*#}
+  url=${buildpack%#*}
+  branch=${buildpack#*#}
 
   if [ "$branch" == "$url" ]; then
     branch=""
   fi
 
   if [ "$url" != "" ]; then
-    echo "-----> Downloading Buildpack: ${NAME}"
+    echo "-----> Downloading Buildpack: ${name}"
 
     if [[ "$url" =~ \.tgz$ ]] || [[ "$url" =~ \.tgz\? ]]; then
       mkdir -p "$dir"
@@ -147,12 +151,12 @@ compile_buildpack_v2()
     # we'll get errors later if these are needed and don't exist
     chmod -f +x "$dir/bin/{detect,compile,release}" || true
 
-    framework=$("$dir"/bin/detect "$1")
+    framework=$("$dir"/bin/detect "$build_dir")
 
     # shellcheck disable=SC2181
     if [ $? == 0 ]; then
       echo "-----> Detected Framework: $framework"
-      "$dir"/bin/compile "$1" "$2" "$3"
+      "$dir"/bin/compile "$build_dir" "$cache_dir" "$env_dir"
 
       # shellcheck disable=SC2181
       if [ $? != 0 ]; then
@@ -168,7 +172,7 @@ compile_buildpack_v2()
       fi
 
       if [ -x "$dir/bin/release" ]; then
-        "$dir"/bin/release "$1" > "$1"/last_pack_release.out
+        "$dir"/bin/release "$build_dir" > "$1"/last_pack_release.out
       fi
     else
       echo "Couldn't detect any framework for this buildpack. Exiting."

--- a/spec/cnb/buildpack_spec.rb
+++ b/spec/cnb/buildpack_spec.rb
@@ -102,7 +102,7 @@ module HerokuBuildpackRuby
             DEPENDENCIES
           EOM
 
-          CnbRun.new(dir, buildpack_paths: ["heroku/jvm", buildpack_path]).call do |app|
+          CnbRun.new(dir, buildpack_paths: ["heroku/jvm@0.1.3", buildpack_path]).call do |app|
             expect(app.output).to include("[Installing Java]")
             expect(app.output).to include("Using Ruby version: 2.5.7-jruby-9.2.13.0")
             expect(app.output).to include("Bundle complete")

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -93,8 +93,8 @@ module HerokuBuildpackRuby
           end
 
           # Test that the system path isn't clobbered
-          app.run_multi("which bash") do |out, status|
-            expect(out.strip).to eq("/bin/bash")
+          app.run_multi("which -a bash") do |out, status|
+            expect(out.strip).to include("/bin/bash")
             expect(status.success?).to be_truthy
           end
 


### PR DESCRIPTION
Previously the function `compile_buildpack_v2` directly uses `$1`, `$2`, and `$3`. This change updates this function to instead use named local variables.

- In addition, there was a typo in the output to the user.
- Update gems