### PR TITLE
[changelog skip] Set default env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@
 - We will set a default "web" process type based on the contents of your Gemfile.lock
   - Use the Procfile to override
 
+- We will set a default for the following environment variables:
+  - RACK_ENV
+  - RAILS_ENV
+  - JRUBY_OPTS
+  - DISABLE_SPRING
+  - SECRET_KEY_BASE
+  - MALLOC_ARENA_MAX
+  - RAILS_LOG_TO_STDOUT
+  - RAILS_SERVE_STATIC_FILES
+
 Goal: Convert all "may" statements to a more specific "will" so we're explicit about when thing shappen
 
 ## Internal Concepts

--- a/lib/heroku_buildpack_ruby.rb
+++ b/lib/heroku_buildpack_ruby.rb
@@ -10,6 +10,7 @@ require_relative "heroku_buildpack_ruby/metadata.rb"
 
 require_relative "heroku_buildpack_ruby/rake_detect.rb"
 require_relative "heroku_buildpack_ruby/assets_precompile.rb"
+require_relative "heroku_buildpack_ruby/set_default_env_vars.rb"
 
 require_relative "heroku_buildpack_ruby/release_launch_info.rb"
 
@@ -67,6 +68,11 @@ module HerokuBuildpackRuby
         ruby_install_dir: ruby_install_dir,
         bundler_install_dir: bundler_install_dir,
         buildpack_ruby_path: buildpack_ruby_path,
+      ).call
+
+      SetDefaultEnvVars.new(
+        metadata: metadata,
+        environment: "production"
       ).call
 
       gems_cache_copy.call do |gems_dir|
@@ -136,6 +142,12 @@ module HerokuBuildpackRuby
         ruby_install_dir: ruby_install_dir,
         bundler_install_dir: bundler_install_dir,
         buildpack_ruby_path: buildpack_ruby_path,
+      ).call
+
+
+      SetDefaultEnvVars.new(
+        metadata: metadata,
+        environment: "production"
       ).call
 
       BundleInstall.new(

--- a/lib/heroku_buildpack_ruby/metadata/cnb.rb
+++ b/lib/heroku_buildpack_ruby/metadata/cnb.rb
@@ -12,9 +12,9 @@ module HerokuBuildpackRuby
     #
     #   layers_dir = Dir.pwd
     #   metadata = Metadata::CNB.new(dir: layers_dir, name: :ruby)
-    #   metadata.set(:foo => "bar")
-    #   metadata.get(:foo) # => "bar"
-    #   metadata.fetch(:cinco) do
+    #   metadata.layer(:ruby).set(:foo => "bar")
+    #   metadata.layer(:ruby).get(:foo) # => "bar"
+    #   metadata.layer(:ruby).fetch(:cinco) do
     #     "a good boy"
     #   end
     #   # => "a good boy"

--- a/lib/heroku_buildpack_ruby/metadata/v2.rb
+++ b/lib/heroku_buildpack_ruby/metadata/v2.rb
@@ -12,9 +12,9 @@ module HerokuBuildpackRuby
     #
     #   cache_dir = Dir.pwd
     #   metadata = Metadata::V2.new(dir: cache_dir, name: :ruby)
-    #   metadata.set(:foo => "bar")
-    #   metadata.get(:foo) # => "bar"
-    #   metadata.fetch(:cinco) do
+    #   metadata.layer(:ruby).set(:foo => "bar")
+    #   metadata.layer(:ruby).get(:foo) # => "bar"
+    #   metadata.layer(:ruby).fetch(:cinco) do
     #     "a good boy"
     #   end
     #   # => "a good boy"

--- a/lib/heroku_buildpack_ruby/set_default_env_vars.rb
+++ b/lib/heroku_buildpack_ruby/set_default_env_vars.rb
@@ -1,0 +1,52 @@
+require "securerandom"
+
+module HerokuBuildpackRuby
+  # Sets default env vars for ruby apps
+  #
+  # Example:
+  #
+  #   SetDefaultEnvVars.new(
+  #     metadata: metadata,
+  #     environment: "production"
+  #   ).call
+  #
+  #   puts ENV["RAILS_ENV"]
+  #   # => "production"
+  class SetDefaultEnvVars
+    RACK_ENV = EnvProxy.default("RACK_ENV")
+    RAILS_ENV = EnvProxy.default("RAILS_ENV")
+    JRUBY_OPTS = EnvProxy.default("JRUBY_OPTS")
+
+    DISABLE_SPRING_ENV = EnvProxy.default("DISABLE_SPRING")
+    SECRET_KEY_BASE_ENV = EnvProxy.default("SECRET_KEY_BASE")
+    MALLOC_ARENA_MAX_ENV = EnvProxy.default("MALLOC_ARENA_MAX")
+
+    RAILS_LOG_TO_STDOUT_ENV = EnvProxy.default("RAILS_LOG_TO_STDOUT")
+    RAILS_SERVE_STATIC_FILES_ENV = EnvProxy.default("RAILS_SERVE_STATIC_FILES")
+
+    private; attr_reader :environment, :metadata; public
+
+    def initialize(environment:, metadata: )
+      @metadata = metadata.layer(:ruby)
+      @environment = environment
+    end
+
+    def call
+      RACK_ENV.set_default(ruby: environment)
+      RAILS_ENV.set_default(ruby: environment)
+      JRUBY_OPTS.set_default(ruby: "-Xcompile.invokedynamic=false")
+
+      DISABLE_SPRING_ENV.set_default(ruby: "1")
+      SECRET_KEY_BASE_ENV.set_default(ruby: secret_key_base)
+      MALLOC_ARENA_MAX_ENV.set_default(ruby: "2")
+
+      RAILS_LOG_TO_STDOUT_ENV.set_default(ruby: "enabled")
+      RAILS_SERVE_STATIC_FILES_ENV.set_default(ruby: "enabled")
+    end
+
+    private def secret_key_base
+      metadata.fetch(:secret_key_base_default) { SecureRandom.hex(64) }
+    end
+  end
+end
+

--- a/lib/heroku_buildpack_ruby/set_default_env_vars.rb
+++ b/lib/heroku_buildpack_ruby/set_default_env_vars.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "securerandom"
 
 module HerokuBuildpackRuby

--- a/spec/cnb/buildpack_spec.rb
+++ b/spec/cnb/buildpack_spec.rb
@@ -169,5 +169,20 @@ module HerokuBuildpackRuby
         expect(app.output).to include(%Q{BUNDLE_WITHOUT="periwinkle"})
       end
     end
+
+    it "rails getting started guide" do
+      # TODO, detect exectjs at detect time and remove heroku/nodejs from buildpacks path
+      skip("Needs execjs integration to force install of node even when package.json is not present")
+
+      CnbRun.new(
+        hatchet_path("ruby_apps/ruby-getting-started"),
+        buildpack_paths: ["heroku/nodejs", buildpack_path],
+      ).call do |app|
+        app.run_multi("rails runner 'puts ENV[%Q{RAILS_SERVE_STATIC_FILES}].present?'") do |out, status|
+          expect(out).to match(/true/)
+          expect(status).to be_truthy
+        end
+      end
+    end
   end
 end

--- a/spec/hatchet/buildpack_spec.rb
+++ b/spec/hatchet/buildpack_spec.rb
@@ -46,10 +46,17 @@ module HerokuBuildpackRuby
       end
     end
 
-    it "getting started guide" do
-      Hatchet::Runner.new("ruby-getting-started").deploy do |app|
+    it "rails getting started guide" do
+      skip("Must set HATCHET_EXPENSIVE_MODE") unless ENV["HATCHET_EXPENSIVE_MODE"]
+
+      Hatchet::Runner.new("ruby-getting-started", run_multi: true).deploy do |app|
         # TODO: Remove asset fragment cache before runtime for reduced slug size
         # expect(app.run("ls tmp/cache/assets")).to_not match("sprockets")
+
+        app.run_multi("rails runner 'puts ENV[%Q{RAILS_SERVE_STATIC_FILES}].present?'") do |out, status|
+          expect(out).to match(/true/)
+          expect(status).to be_truthy
+        end
       end
     end
 

--- a/spec/unit/set_default_env_vars_spec.rb
+++ b/spec/unit/set_default_env_vars_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper.rb"
+
+module HerokuBuildpackRuby
+  RSpec.describe "SetDefaultEnvVars" do
+    it "sets env vars" do
+      isolate_in_fork do
+        expected = {
+          "RACK_ENV" => "production",
+          "RAILS_ENV" => "production",
+          "JRUBY_OPTS" => "-Xcompile.invokedynamic=false",
+          "DISABLE_SPRING" => "1",
+          "MALLOC_ARENA_MAX" => "2",
+          "RAILS_LOG_TO_STDOUT" => "enabled",
+          "RAILS_SERVE_STATIC_FILES" => "enabled",
+        }
+        expected.each {|key, _| ENV.delete(key) } # Pristine environment
+
+        null = Metadata::Null.new
+        SetDefaultEnvVars.new(
+          metadata: null,
+          environment: "production",
+        ).call
+
+        expected.each { |key, value| expect(ENV[key]).to eq(value) }
+
+        expect(ENV["SECRET_KEY_BASE"]).to_not be_empty
+        expect(ENV["SECRET_KEY_BASE"].length).to eq(SecureRandom.hex(64).length)
+      end
+    end
+
+    it "persists secret key base" do
+      isolate_in_fork do
+        null = Metadata::Null.new
+        null.layer(:ruby).set(:secret_key_base_default => "i can neither confirm nor deny")
+
+        SetDefaultEnvVars.new(
+          metadata: null,
+          environment: "production",
+        ).call
+
+        expect(ENV["SECRET_KEY_BASE"]).to eq("i can neither confirm nor deny")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously some of these env vars were set conditionally based on library presence (such as only setting JRUBY_OPTS  if the app is using jruby). For these selected env vars, there's minimal risk in setting an env var default that is ultimately not needed. As a result all env vars are set for all Ruby applications.

Current default env vars:

- RACK_ENV
- RAILS_ENV
- JRUBY_OPTS
- DISABLE_SPRING
- SECRET_KEY_BASE
- MALLOC_ARENA_MAX
- RAILS_LOG_TO_STDOUT
- RAILS_SERVE_STATIC_FILES

